### PR TITLE
Setup xcode project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ android-x86_64:
 	echo - target/x86_64-linux-android/release/libwysiwyg_ffi.so
 	echo - bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
 
-IOS_GENERATED_DIR := ../../examples/example-ios/Generated
+IOS_PACKAGE_DIR := ../../examples/example-ios/Packages/WysiwygComposer/
+IOS_GENERATION_DIR := ../../examples/example-ios/Generated
 
 ios:
 	cd bindings/wysiwyg-ffi && \
@@ -26,25 +27,25 @@ ios:
 	  ../../target/x86_64-apple-ios/release/libwysiwyg_ffi.a \
 	  ../../target/aarch64-apple-ios-sim/release/libwysiwyg_ffi.a \
 	  -output ../../target/ios-simulator/libwysiwyg_ffi.a && \
-	rm -rf ${IOS_GENERATED_DIR} && \
-	mkdir -p ${IOS_GENERATED_DIR} && \
+	rm -rf ${IOS_PACKAGE_DIR}/WysiwygComposerFFI.xcframework && \
+	rm -f ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/WysiwygComposer.swift && \
+	rm -rf ${IOS_GENERATION_DIR} && \
+	mkdir -p ${IOS_GENERATION_DIR} && \
 	uniffi-bindgen \
 		generate src/wysiwyg_composer.udl \
 		--language swift \
 		--config uniffi.toml \
-		--out-dir ${IOS_GENERATED_DIR} && \
-	mkdir -p ${IOS_GENERATED_DIR}/headers && \
-	mkdir -p ${IOS_GENERATED_DIR}/Sources && \
-	mv ${IOS_GENERATED_DIR}/*.h         ${IOS_GENERATED_DIR}/headers/ && \
-	mv ${IOS_GENERATED_DIR}/*.modulemap ${IOS_GENERATED_DIR}/headers/module.modulemap && \
-	mv ${IOS_GENERATED_DIR}/*.swift     ${IOS_GENERATED_DIR}/Sources && \
+		--out-dir ${IOS_GENERATION_DIR} && \
+	mkdir -p ${IOS_GENERATION_DIR}/headers && \
+	mv ${IOS_GENERATION_DIR}/*.h         ${IOS_GENERATION_DIR}/headers/ && \
+	mv ${IOS_GENERATION_DIR}/*.modulemap ${IOS_GENERATION_DIR}/headers/module.modulemap && \
+	mv ${IOS_GENERATION_DIR}/*.swift     ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/ && \
 	xcodebuild -create-xcframework \
 	  -library ../../target/aarch64-apple-ios/release/libwysiwyg_ffi.a \
-	  -headers ${IOS_GENERATED_DIR}/headers \
+	  -headers ${IOS_GENERATION_DIR}/headers \
 	  -library ../../target/ios-simulator/libwysiwyg_ffi.a \
-	  -headers ${IOS_GENERATED_DIR}/headers \
-	  -output ${IOS_GENERATED_DIR}/WysiwygComposerFFI.xcframework && \
-	rm -rf ${IOS_GENERATED_DIR}/headers
+	  -headers ${IOS_GENERATION_DIR}/headers \
+	  -output ${IOS_PACKAGE_DIR}/WysiwygComposerFFI.xcframework
 web:
 	cd bindings/wysiwyg-wasm && \
 	npm install && \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ android-x86_64:
 	echo - target/x86_64-linux-android/release/libwysiwyg_ffi.so
 	echo - bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
 
-EXAMPLE_IOS := ../../examples/example-ios
+IOS_GENERATED_DIR := ../../examples/example-ios/Generated
 
 ios:
 	cd bindings/wysiwyg-ffi && \
@@ -26,27 +26,25 @@ ios:
 	  ../../target/x86_64-apple-ios/release/libwysiwyg_ffi.a \
 	  ../../target/aarch64-apple-ios-sim/release/libwysiwyg_ffi.a \
 	  -output ../../target/ios-simulator/libwysiwyg_ffi.a && \
-	mkdir -p ${EXAMPLE_IOS} && \
-	rm -rf ${EXAMPLE_IOS}/Sources && \
-	rm -rf ${EXAMPLE_IOS}/headers && \
-	rm -rf ${EXAMPLE_IOS}/LibWysiwyg.xcframework && \
+	rm -rf ${IOS_GENERATED_DIR} && \
+	mkdir -p ${IOS_GENERATED_DIR} && \
 	uniffi-bindgen \
 		generate src/wysiwyg_composer.udl \
 		--language swift \
 		--config uniffi.toml \
-		--out-dir ${EXAMPLE_IOS} && \
-	mkdir -p ${EXAMPLE_IOS}/headers && \
-	mkdir -p ${EXAMPLE_IOS}/Sources && \
-	mv ${EXAMPLE_IOS}/*.h         ${EXAMPLE_IOS}/headers/ && \
-	mv ${EXAMPLE_IOS}/*.modulemap ${EXAMPLE_IOS}/headers/module.modulemap && \
-	mv ${EXAMPLE_IOS}/*.swift     ${EXAMPLE_IOS}/Sources/ && \
+		--out-dir ${IOS_GENERATED_DIR} && \
+	mkdir -p ${IOS_GENERATED_DIR}/headers && \
+	mkdir -p ${IOS_GENERATED_DIR}/Sources && \
+	mv ${IOS_GENERATED_DIR}/*.h         ${IOS_GENERATED_DIR}/headers/ && \
+	mv ${IOS_GENERATED_DIR}/*.modulemap ${IOS_GENERATED_DIR}/headers/module.modulemap && \
+	mv ${IOS_GENERATED_DIR}/*.swift     ${IOS_GENERATED_DIR}/Sources && \
 	xcodebuild -create-xcframework \
 	  -library ../../target/aarch64-apple-ios/release/libwysiwyg_ffi.a \
-	  -headers ${EXAMPLE_IOS}/headers \
+	  -headers ${IOS_GENERATED_DIR}/headers \
 	  -library ../../target/ios-simulator/libwysiwyg_ffi.a \
-	  -headers ${EXAMPLE_IOS}/headers \
-	  -output ${EXAMPLE_IOS}/LibWysiwyg.xcframework
-
+	  -headers ${IOS_GENERATED_DIR}/headers \
+	  -output ${IOS_GENERATED_DIR}/WysiwygComposerFFI.xcframework && \
+	rm -rf ${IOS_GENERATED_DIR}/headers
 web:
 	cd bindings/wysiwyg-wasm && \
 	npm install && \

--- a/examples/example-ios/.gitignore
+++ b/examples/example-ios/.gitignore
@@ -1,0 +1,9 @@
+# ENV
+build/
+xcuserdata
+*.xcuserstate
+.vscode/
+vendor/
+.DS_Store
+# Generated
+Generated/

--- a/examples/example-ios/Packages/WysiwygComposer/.gitignore
+++ b/examples/example-ios/Packages/WysiwygComposer/.gitignore
@@ -1,0 +1,13 @@
+# ENV
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+# Generated
+WysiwygComposerFFI.xcframework
+Sources/WysiwygComposer/WysiwygComposer.swift

--- a/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/xcshareddata/xcschemes/WysiwygComposer.xcscheme
+++ b/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/xcshareddata/xcschemes/WysiwygComposer.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WysiwygComposer"
+               BuildableName = "WysiwygComposer"
+               BlueprintName = "WysiwygComposer"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WysiwygComposer"
+            BuildableName = "WysiwygComposer"
+            BlueprintName = "WysiwygComposer"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/xcshareddata/xcschemes/WysiwygComposerTests.xcscheme
+++ b/examples/example-ios/Packages/WysiwygComposer/.swiftpm/xcode/xcshareddata/xcschemes/WysiwygComposerTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WysiwygComposerTests"
+               BuildableName = "WysiwygComposerTests"
+               BlueprintName = "WysiwygComposerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/example-ios/Packages/WysiwygComposer/Package.swift
+++ b/examples/example-ios/Packages/WysiwygComposer/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WysiwygComposer",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "WysiwygComposer",
+            targets: ["WysiwygComposer"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "WysiwygComposerFFI",
+            path: "WysiwygComposerFFI.xcframework"
+        ),
+        .target(
+            name: "WysiwygComposer",
+            dependencies: [
+                .target(name: "WysiwygComposerFFI")
+            ]
+        ),
+        .testTarget(
+            name: "WysiwygComposerTests",
+            dependencies: ["WysiwygComposer"]),
+    ]
+)

--- a/examples/example-ios/Packages/WysiwygComposer/README.md
+++ b/examples/example-ios/Packages/WysiwygComposer/README.md
@@ -1,0 +1,9 @@
+# WysiwygComposer
+
+This package contains most of the source code powering our WYSIWYG editor.
+
+It is composed of: 
+* Static libraries generated from Rust, packaged in a XCFramework.
+* Swift bindings to interact with these libraries.
+* Components built on top of these bindings.
+* Unit tests validating this.

--- a/examples/example-ios/Packages/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygTextView.swift
+++ b/examples/example-ios/Packages/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygTextView.swift
@@ -1,0 +1,34 @@
+//
+//  WysiwygTextView.swift
+//  
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import SwiftUI
+
+/// A basic view that displays a text passing through the Rust library.
+public struct WysiwygTextView: View {
+    // MARK: - Public
+    public var body: some View {
+        Text(createSampleRustString())
+    }
+
+    public init() {}
+
+    // MARK: - Private
+    private func createSampleRustString() -> String {
+        let model = newComposerModel()
+        let update = model.replaceText(newText: "Test string that goes through Rust")
+        let rawHTML: String
+        switch update.textUpdate() {
+        case .replaceAll(replacementHtml: let html,
+                         selectionStartCodepoint: _,
+                         selectionEndCodepoint: _):
+            rawHTML = html
+        default:
+            rawHTML = "Unable to load from Rust"
+        }
+        return rawHTML
+    }
+}

--- a/examples/example-ios/Packages/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/examples/example-ios/Packages/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WysiwygComposer
+
+final class WysiwygComposerTests: XCTestCase {
+    func testExample() throws {
+        let composer = newComposerModel()
+        let update = composer.replaceText(newText: "Test")
+        switch update.textUpdate() {
+        case .keep:
+            XCTFail()
+        case .replaceAll(replacementHtml: let html,
+                         selectionStartCodepoint: _,
+                         selectionEndCodepoint: _):
+            XCTAssertEqual(html, "Test")
+        }
+    }
+}

--- a/examples/example-ios/Wysiwyg.xcodeproj/project.pbxproj
+++ b/examples/example-ios/Wysiwyg.xcodeproj/project.pbxproj
@@ -1,0 +1,612 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A6472CAB2886CF830021A0E8 /* WysiwygApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CAA2886CF830021A0E8 /* WysiwygApp.swift */; };
+		A6472CAD2886CF830021A0E8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CAC2886CF830021A0E8 /* ContentView.swift */; };
+		A6472CAF2886CF840021A0E8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6472CAE2886CF840021A0E8 /* Assets.xcassets */; };
+		A6472CB22886CF840021A0E8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6472CB12886CF840021A0E8 /* Preview Assets.xcassets */; };
+		A6472CBC2886CF840021A0E8 /* WysiwygTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CBB2886CF840021A0E8 /* WysiwygTests.swift */; };
+		A6472CC62886CF840021A0E8 /* WysiwygUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */; };
+		A6472CC82886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CC72886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift */; };
+		A6472CD72886CFD50021A0E8 /* WysiwygComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */; };
+		A6472CD92886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A6472CB82886CF840021A0E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A6472C9F2886CF830021A0E8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A6472CA62886CF830021A0E8;
+			remoteInfo = Wysiwyg;
+		};
+		A6472CC22886CF840021A0E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A6472C9F2886CF830021A0E8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A6472CA62886CF830021A0E8;
+			remoteInfo = Wysiwyg;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A6472CA72886CF830021A0E8 /* Wysiwyg.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wysiwyg.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6472CAA2886CF830021A0E8 /* WysiwygApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygApp.swift; sourceTree = "<group>"; };
+		A6472CAC2886CF830021A0E8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A6472CAE2886CF840021A0E8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A6472CB12886CF840021A0E8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A6472CB72886CF840021A0E8 /* WysiwygTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WysiwygTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6472CBB2886CF840021A0E8 /* WysiwygTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygTests.swift; sourceTree = "<group>"; };
+		A6472CC12886CF840021A0E8 /* WysiwygUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WysiwygUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygUITests.swift; sourceTree = "<group>"; };
+		A6472CC72886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WysiwygComposer.swift; sourceTree = "<group>"; };
+		A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = WysiwygComposerFFI.xcframework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A6472CA42886CF830021A0E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6472CD92886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CB42886CF840021A0E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CBE2886CF840021A0E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A6472C9E2886CF830021A0E8 = {
+			isa = PBXGroup;
+			children = (
+				A6472CD42886CFA80021A0E8 /* Generated */,
+				A6472CA92886CF830021A0E8 /* Wysiwyg */,
+				A6472CBA2886CF840021A0E8 /* WysiwygTests */,
+				A6472CC42886CF840021A0E8 /* WysiwygUITests */,
+				A6472CA82886CF830021A0E8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A6472CA82886CF830021A0E8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CA72886CF830021A0E8 /* Wysiwyg.app */,
+				A6472CB72886CF840021A0E8 /* WysiwygTests.xctest */,
+				A6472CC12886CF840021A0E8 /* WysiwygUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A6472CA92886CF830021A0E8 /* Wysiwyg */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CAA2886CF830021A0E8 /* WysiwygApp.swift */,
+				A6472CAC2886CF830021A0E8 /* ContentView.swift */,
+				A6472CAE2886CF840021A0E8 /* Assets.xcassets */,
+				A6472CB02886CF840021A0E8 /* Preview Content */,
+			);
+			path = Wysiwyg;
+			sourceTree = "<group>";
+		};
+		A6472CB02886CF840021A0E8 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CB12886CF840021A0E8 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		A6472CBA2886CF840021A0E8 /* WysiwygTests */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CBB2886CF840021A0E8 /* WysiwygTests.swift */,
+			);
+			path = WysiwygTests;
+			sourceTree = "<group>";
+		};
+		A6472CC42886CF840021A0E8 /* WysiwygUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */,
+				A6472CC72886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift */,
+			);
+			path = WysiwygUITests;
+			sourceTree = "<group>";
+		};
+		A6472CD42886CFA80021A0E8 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */,
+				A6472CD52886CFB00021A0E8 /* Sources */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
+		A6472CD52886CFB00021A0E8 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A6472CA62886CF830021A0E8 /* Wysiwyg */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A6472CCB2886CF840021A0E8 /* Build configuration list for PBXNativeTarget "Wysiwyg" */;
+			buildPhases = (
+				A6472CA32886CF830021A0E8 /* Sources */,
+				A6472CA42886CF830021A0E8 /* Frameworks */,
+				A6472CA52886CF830021A0E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Wysiwyg;
+			productName = Wysiwyg;
+			productReference = A6472CA72886CF830021A0E8 /* Wysiwyg.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A6472CB62886CF840021A0E8 /* WysiwygTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A6472CCE2886CF840021A0E8 /* Build configuration list for PBXNativeTarget "WysiwygTests" */;
+			buildPhases = (
+				A6472CB32886CF840021A0E8 /* Sources */,
+				A6472CB42886CF840021A0E8 /* Frameworks */,
+				A6472CB52886CF840021A0E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A6472CB92886CF840021A0E8 /* PBXTargetDependency */,
+			);
+			name = WysiwygTests;
+			productName = WysiwygTests;
+			productReference = A6472CB72886CF840021A0E8 /* WysiwygTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A6472CC02886CF840021A0E8 /* WysiwygUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A6472CD12886CF840021A0E8 /* Build configuration list for PBXNativeTarget "WysiwygUITests" */;
+			buildPhases = (
+				A6472CBD2886CF840021A0E8 /* Sources */,
+				A6472CBE2886CF840021A0E8 /* Frameworks */,
+				A6472CBF2886CF840021A0E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A6472CC32886CF840021A0E8 /* PBXTargetDependency */,
+			);
+			name = WysiwygUITests;
+			productName = WysiwygUITests;
+			productReference = A6472CC12886CF840021A0E8 /* WysiwygUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A6472C9F2886CF830021A0E8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					A6472CA62886CF830021A0E8 = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+					A6472CB62886CF840021A0E8 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = A6472CA62886CF830021A0E8;
+					};
+					A6472CC02886CF840021A0E8 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = A6472CA62886CF830021A0E8;
+					};
+				};
+			};
+			buildConfigurationList = A6472CA22886CF830021A0E8 /* Build configuration list for PBXProject "Wysiwyg" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A6472C9E2886CF830021A0E8;
+			productRefGroup = A6472CA82886CF830021A0E8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A6472CA62886CF830021A0E8 /* Wysiwyg */,
+				A6472CB62886CF840021A0E8 /* WysiwygTests */,
+				A6472CC02886CF840021A0E8 /* WysiwygUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A6472CA52886CF830021A0E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6472CB22886CF840021A0E8 /* Preview Assets.xcassets in Resources */,
+				A6472CAF2886CF840021A0E8 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CB52886CF840021A0E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CBF2886CF840021A0E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A6472CA32886CF830021A0E8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6472CAD2886CF830021A0E8 /* ContentView.swift in Sources */,
+				A6472CAB2886CF830021A0E8 /* WysiwygApp.swift in Sources */,
+				A6472CD72886CFD50021A0E8 /* WysiwygComposer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CB32886CF840021A0E8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6472CBC2886CF840021A0E8 /* WysiwygTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6472CBD2886CF840021A0E8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6472CC82886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift in Sources */,
+				A6472CC62886CF840021A0E8 /* WysiwygUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A6472CB92886CF840021A0E8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A6472CA62886CF830021A0E8 /* Wysiwyg */;
+			targetProxy = A6472CB82886CF840021A0E8 /* PBXContainerItemProxy */;
+		};
+		A6472CC32886CF840021A0E8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A6472CA62886CF830021A0E8 /* Wysiwyg */;
+			targetProxy = A6472CC22886CF840021A0E8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A6472CC92886CF840021A0E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A6472CCA2886CF840021A0E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A6472CCC2886CF840021A0E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Wysiwyg/Preview Content\"";
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.Wysiwyg;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A6472CCD2886CF840021A0E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Wysiwyg/Preview Content\"";
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.Wysiwyg;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A6472CCF2886CF840021A0E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.WysiwygTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wysiwyg.app/Wysiwyg";
+			};
+			name = Debug;
+		};
+		A6472CD02886CF840021A0E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.WysiwygTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wysiwyg.app/Wysiwyg";
+			};
+			name = Release;
+		};
+		A6472CD22886CF840021A0E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.WysiwygUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Wysiwyg;
+			};
+			name = Debug;
+		};
+		A6472CD32886CF840021A0E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = im.vector.WysiwygUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Wysiwyg;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A6472CA22886CF830021A0E8 /* Build configuration list for PBXProject "Wysiwyg" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6472CC92886CF840021A0E8 /* Debug */,
+				A6472CCA2886CF840021A0E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A6472CCB2886CF840021A0E8 /* Build configuration list for PBXNativeTarget "Wysiwyg" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6472CCC2886CF840021A0E8 /* Debug */,
+				A6472CCD2886CF840021A0E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A6472CCE2886CF840021A0E8 /* Build configuration list for PBXNativeTarget "WysiwygTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6472CCF2886CF840021A0E8 /* Debug */,
+				A6472CD02886CF840021A0E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A6472CD12886CF840021A0E8 /* Build configuration list for PBXNativeTarget "WysiwygUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6472CD22886CF840021A0E8 /* Debug */,
+				A6472CD32886CF840021A0E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A6472C9F2886CF830021A0E8 /* Project object */;
+}

--- a/examples/example-ios/Wysiwyg.xcodeproj/project.pbxproj
+++ b/examples/example-ios/Wysiwyg.xcodeproj/project.pbxproj
@@ -14,8 +14,7 @@
 		A6472CBC2886CF840021A0E8 /* WysiwygTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CBB2886CF840021A0E8 /* WysiwygTests.swift */; };
 		A6472CC62886CF840021A0E8 /* WysiwygUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */; };
 		A6472CC82886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CC72886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift */; };
-		A6472CD72886CFD50021A0E8 /* WysiwygComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */; };
-		A6472CD92886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */; };
+		A6E6B26F2886D9AA009596F2 /* WysiwygComposer in Frameworks */ = {isa = PBXBuildFile; productRef = A6E6B26E2886D9AA009596F2 /* WysiwygComposer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,8 +45,7 @@
 		A6472CC12886CF840021A0E8 /* WysiwygUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WysiwygUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygUITests.swift; sourceTree = "<group>"; };
 		A6472CC72886CF840021A0E8 /* WysiwygUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WysiwygComposer.swift; sourceTree = "<group>"; };
-		A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = WysiwygComposerFFI.xcframework; sourceTree = "<group>"; };
+		A6E6B2712886DA6E009596F2 /* WysiwygComposer */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = WysiwygComposer; path = Packages/WysiwygComposer; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6472CD92886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework in Frameworks */,
+				A6E6B26F2886D9AA009596F2 /* WysiwygComposer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,11 +77,12 @@
 		A6472C9E2886CF830021A0E8 = {
 			isa = PBXGroup;
 			children = (
-				A6472CD42886CFA80021A0E8 /* Generated */,
+				A6E6B2702886DA6E009596F2 /* Packages */,
 				A6472CA92886CF830021A0E8 /* Wysiwyg */,
 				A6472CBA2886CF840021A0E8 /* WysiwygTests */,
 				A6472CC42886CF840021A0E8 /* WysiwygUITests */,
 				A6472CA82886CF830021A0E8 /* Products */,
+				A6E6B26D2886D9AA009596F2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -133,21 +132,19 @@
 			path = WysiwygUITests;
 			sourceTree = "<group>";
 		};
-		A6472CD42886CFA80021A0E8 /* Generated */ = {
+		A6E6B26D2886D9AA009596F2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A6472CD82886CFDC0021A0E8 /* WysiwygComposerFFI.xcframework */,
-				A6472CD52886CFB00021A0E8 /* Sources */,
 			);
-			path = Generated;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		A6472CD52886CFB00021A0E8 /* Sources */ = {
+		A6E6B2702886DA6E009596F2 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				A6472CD62886CFD50021A0E8 /* WysiwygComposer.swift */,
+				A6E6B2712886DA6E009596F2 /* WysiwygComposer */,
 			);
-			path = Sources;
+			name = Packages;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -166,6 +163,9 @@
 			dependencies = (
 			);
 			name = Wysiwyg;
+			packageProductDependencies = (
+				A6E6B26E2886D9AA009596F2 /* WysiwygComposer */,
+			);
 			productName = Wysiwyg;
 			productReference = A6472CA72886CF830021A0E8 /* Wysiwyg.app */;
 			productType = "com.apple.product-type.application";
@@ -282,7 +282,6 @@
 			files = (
 				A6472CAD2886CF830021A0E8 /* ContentView.swift in Sources */,
 				A6472CAB2886CF830021A0E8 /* WysiwygApp.swift in Sources */,
-				A6472CD72886CFD50021A0E8 /* WysiwygComposer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -607,6 +606,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A6E6B26E2886D9AA009596F2 /* WysiwygComposer */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WysiwygComposer;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = A6472C9F2886CF830021A0E8 /* Project object */;
 }

--- a/examples/example-ios/Wysiwyg.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/example-ios/Wysiwyg.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/example-ios/Wysiwyg.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/example-ios/Wysiwyg.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/example-ios/Wysiwyg/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/example-ios/Wysiwyg/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/example-ios/Wysiwyg/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/example-ios/Wysiwyg/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/example-ios/Wysiwyg/Assets.xcassets/Contents.json
+++ b/examples/example-ios/Wysiwyg/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/example-ios/Wysiwyg/ContentView.swift
+++ b/examples/example-ios/Wysiwyg/ContentView.swift
@@ -6,28 +6,13 @@
 //
 
 import SwiftUI
-import WysiwygComposerFFI
+import WysiwygComposer
+
 
 struct ContentView: View {
     var body: some View {
-        Text(getRustString())
+        WysiwygTextView()
             .padding()
-    }
-
-    // FIXME: remove this test func
-    private func getRustString() -> String {
-        let model = newComposerModel()
-        let update = model.replaceText(newText: "Test string that goes through Rust")
-        let rawHTML: String
-        switch update.textUpdate() {
-        case .replaceAll(replacementHtml: let html,
-                         selectionStartCodepoint: _,
-                         selectionEndCodepoint: _):
-            rawHTML = html
-        default:
-            rawHTML = "Unable to load from Rust"
-        }
-        return rawHTML
     }
 }
 

--- a/examples/example-ios/Wysiwyg/ContentView.swift
+++ b/examples/example-ios/Wysiwyg/ContentView.swift
@@ -1,0 +1,38 @@
+//
+//  ContentView.swift
+//  Wysiwyg
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import SwiftUI
+import WysiwygComposerFFI
+
+struct ContentView: View {
+    var body: some View {
+        Text(getRustString())
+            .padding()
+    }
+
+    // FIXME: remove this test func
+    private func getRustString() -> String {
+        let model = newComposerModel()
+        let update = model.replaceText(newText: "Test string that goes through Rust")
+        let rawHTML: String
+        switch update.textUpdate() {
+        case .replaceAll(replacementHtml: let html,
+                         selectionStartCodepoint: _,
+                         selectionEndCodepoint: _):
+            rawHTML = html
+        default:
+            rawHTML = "Unable to load from Rust"
+        }
+        return rawHTML
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/example-ios/Wysiwyg/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/example-ios/Wysiwyg/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/example-ios/Wysiwyg/WysiwygApp.swift
+++ b/examples/example-ios/Wysiwyg/WysiwygApp.swift
@@ -1,0 +1,17 @@
+//
+//  WysiwygApp.swift
+//  Wysiwyg
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import SwiftUI
+
+@main
+struct WysiwygApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/example-ios/WysiwygTests/WysiwygTests.swift
+++ b/examples/example-ios/WysiwygTests/WysiwygTests.swift
@@ -1,0 +1,36 @@
+//
+//  WysiwygTests.swift
+//  WysiwygTests
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import XCTest
+@testable import Wysiwyg
+
+class WysiwygTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/examples/example-ios/WysiwygUITests/WysiwygUITests.swift
+++ b/examples/example-ios/WysiwygUITests/WysiwygUITests.swift
@@ -1,0 +1,41 @@
+//
+//  WysiwygUITests.swift
+//  WysiwygUITests
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import XCTest
+
+class WysiwygUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/examples/example-ios/WysiwygUITests/WysiwygUITestsLaunchTests.swift
+++ b/examples/example-ios/WysiwygUITests/WysiwygUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  WysiwygUITestsLaunchTests.swift
+//  WysiwygUITests
+//
+//  Created by Arnaud Ringenbach on 19/07/2022.
+//
+
+import XCTest
+
+class WysiwygUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
This sets up a base XCode project. 

It reworks `make ios` a bit as well so that the XCFramework and the Swift bindings are directly moved to a Swift Package expecting their presence.
All required Swift code, as well as unit tests can be added directly to this local package, and the iOS application is only displaying package-provided components.

This could be then easily exported later as a ready-for-use package.