### PR TITLE
Allow formatting of several nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -17,8 +17,7 @@ use crate::dom::parser::parse;
 use crate::dom::UnicodeString;
 use crate::dom::{DomHandle, MultipleNodesRange, Range, SameNodeRange, ToHtml};
 use crate::{
-    ActionResponse, ComposerState, ComposerUpdate, InlineFormatType, Location,
-    NodeJoiner,
+    ActionResponse, ComposerState, ComposerUpdate, Location, NodeJoiner,
 };
 
 #[derive(Clone)]

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -81,6 +81,7 @@ impl DomHandle {
 
     pub fn prev_sibling(&self) -> Self {
         let index_in_parent = self.index_in_parent();
+        assert!(index_in_parent > 0);
         let mut path = self.parent_handle().path;
         path.push(index_in_parent - 1);
         Self { path }

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -71,4 +71,18 @@ impl DomHandle {
     pub fn is_root(&self) -> bool {
         self.path.is_empty()
     }
+
+    pub fn next_sibling(&self) -> Self {
+        let index_in_parent = self.index_in_parent();
+        let mut path = self.parent_handle().path;
+        path.push(index_in_parent + 1);
+        Self { path }
+    }
+
+    pub fn prev_sibling(&self) -> Self {
+        let index_in_parent = self.index_in_parent();
+        let mut path = self.parent_handle().path;
+        path.push(index_in_parent - 1);
+        Self { path }
+    }
 }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -259,7 +259,7 @@ mod test {
         // Create a simple DOM
         let dom = Dom::new(vec![
             DomNode::Text(TextNode::from(utf16("a"))),
-            DomNode::new_formatting(
+            DomNode::new_formatting_from_tag(
                 utf16("b"),
                 vec![DomNode::Text(TextNode::from(utf16("b")))],
             ),
@@ -274,7 +274,7 @@ mod test {
         // Create a simple DOM
         let dom = Dom::new(vec![
             DomNode::Text(TextNode::from(utf16("a"))),
-            DomNode::new_formatting(
+            DomNode::new_formatting_from_tag(
                 utf16("b"),
                 vec![DomNode::Text(TextNode::from(utf16("b")))],
             ),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -70,16 +70,16 @@ where
     pub fn new_formatting_from_tag(
         format: S,
         children: Vec<DomNode<S>>,
-    ) -> Self {
-        Self {
-            name: format.clone(),
-            kind: ContainerNodeKind::Formatting(
-                InlineFormatType::try_from(format).unwrap(),
-            ),
-            attrs: None,
-            children,
-            handle: DomHandle::new_unset(),
-        }
+    ) -> Option<Self> {
+        InlineFormatType::try_from(format.clone())
+            .map(|f| Self {
+                name: format,
+                kind: ContainerNodeKind::Formatting(f),
+                attrs: None,
+                children,
+                handle: DomHandle::new_unset(),
+            })
+            .ok()
     }
 
     pub fn new_formatting(
@@ -283,6 +283,7 @@ where
                 into_node.set_data(new_data.clone());
                 self.remove_child(from_index);
             }
+            // We don't want to merge Container and Text nodes
             _ => {}
         };
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -249,18 +249,14 @@ where
         }
     }
 
-    pub fn is_same_kind(&self, other: &ContainerNode<S>) -> bool {
+    pub fn can_merge_with(&self, other: &ContainerNode<S>) -> bool {
         match (&self.kind, &other.kind) {
             (ContainerNodeKind::Generic, ContainerNodeKind::Generic) => true,
-            (ContainerNodeKind::Link(_), ContainerNodeKind::Link(_)) => true,
             // Maybe this should be re-checked
             (
                 ContainerNodeKind::Formatting(a),
                 ContainerNodeKind::Formatting(b),
             ) => a == b,
-            // TODO: Should be re-done to distinguish ul and ol
-            (ContainerNodeKind::List, ContainerNodeKind::List) => true,
-            (ContainerNodeKind::ListItem, ContainerNodeKind::ListItem) => true,
             _ => false,
         }
     }
@@ -272,7 +268,7 @@ where
         let into_node = self.children.get_mut(into_index).unwrap();
         match (into_node, from_node) {
             (DomNode::Container(into_node), DomNode::Container(from_node)) => {
-                if !into_node.is_same_kind(&from_node) {
+                if !into_node.can_merge_with(&from_node) {
                     return;
                 }
                 for c in from_node.children() {
@@ -289,16 +285,6 @@ where
             }
             _ => {}
         };
-    }
-
-    pub fn duplicate(&self) -> Self {
-        Self {
-            name: self.name.clone(),
-            kind: self.kind.clone(),
-            attrs: self.attrs.clone(),
-            children: vec![],
-            handle: DomHandle::new_unset(),
-        }
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -45,9 +45,10 @@ where
         format: S,
         children: Vec<DomNode<S>>,
     ) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_formatting_from_tag(
-            format, children,
-        ))
+        DomNode::Container(
+            ContainerNode::new_formatting_from_tag(format.clone(), children)
+                .expect(&format!("Unknown format tag {}", format.to_utf8())),
+        )
     }
 
     pub fn new_list(list_type: S, children: Vec<DomNode<S>>) -> DomNode<S> {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -19,6 +19,7 @@ use crate::dom::nodes::text_node::TextNode;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::UnicodeString;
+use crate::InlineFormatType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DomNode<S>
@@ -33,8 +34,20 @@ impl<S> DomNode<S>
 where
     S: UnicodeString,
 {
-    pub fn new_formatting(format: S, children: Vec<DomNode<S>>) -> DomNode<S> {
+    pub fn new_formatting(
+        format: InlineFormatType,
+        children: Vec<DomNode<S>>,
+    ) -> DomNode<S> {
         DomNode::Container(ContainerNode::new_formatting(format, children))
+    }
+
+    pub fn new_formatting_from_tag(
+        format: S,
+        children: Vec<DomNode<S>>,
+    ) -> DomNode<S> {
+        DomNode::Container(ContainerNode::new_formatting_from_tag(
+            format, children,
+        ))
     }
 
     pub fn new_list(list_type: S, children: Vec<DomNode<S>>) -> DomNode<S> {
@@ -71,6 +84,14 @@ where
 
     pub fn new_link(url: S, children: Vec<DomNode<S>>) -> DomNode<S> {
         DomNode::Container(ContainerNode::new_link(url, children))
+    }
+
+    pub fn is_container_node(&self) -> bool {
+        matches!(self, DomNode::Container(_))
+    }
+
+    pub fn is_text_node(&self) -> bool {
+        matches!(self, DomNode::Text(_))
     }
 
     pub fn is_structure_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -64,7 +64,7 @@ where
     where
         S: UnicodeString,
     {
-        DomNode::Container(ContainerNode::new_formatting(
+        DomNode::Container(ContainerNode::new_formatting_from_tag(
             S::from_str(tag),
             Vec::new(),
         ))

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -64,10 +64,13 @@ where
     where
         S: UnicodeString,
     {
-        DomNode::Container(ContainerNode::new_formatting_from_tag(
-            S::from_str(tag),
-            Vec::new(),
-        ))
+        DomNode::Container(
+            ContainerNode::new_formatting_from_tag(
+                S::from_str(tag),
+                Vec::new(),
+            )
+            .expect(&format!("Unknown format tag {}", tag)),
+        )
     }
 
     /// Create a link node

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -43,29 +43,62 @@ pub struct SameNodeRange {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DomLocation {
     pub node_handle: DomHandle,
+    pub position: usize,
     pub start_offset: usize,
     pub end_offset: usize,
+    pub length: usize,
+    pub is_leaf: bool,
 }
 
 impl DomLocation {
     pub fn new(
         node_handle: DomHandle,
+        position: usize,
         start_offset: usize,
         end_offset: usize,
+        length: usize,
+        is_leaf: bool,
     ) -> Self {
         Self {
             node_handle,
+            position,
             start_offset,
             end_offset,
+            length,
+            is_leaf,
         }
     }
 
+    /// Calculated index in the Dom based on the [position] and [start_offset] values.
+    pub fn index_in_dom(&self) -> usize {
+        self.position + self.start_offset
+    }
+
+    /// Create a copy of this Location, but with start and end offsets reversed
     pub fn reversed(&self) -> Self {
         Self {
             node_handle: self.node_handle.clone(),
+            position: self.position,
             start_offset: self.end_offset,
             end_offset: self.start_offset,
+            length: self.length,
+            is_leaf: self.is_leaf,
         }
+    }
+
+    /// Whether the selection starts at this location or not
+    pub fn is_start(&self) -> bool {
+        self.end_offset == self.length
+    }
+
+    /// Whether the selection ends at this location or not
+    pub fn is_end(&self) -> bool {
+        self.start_offset == 0
+    }
+
+    /// Whether the selection completely covers this location
+    pub fn is_covered(&self) -> bool {
+        self.is_start() && self.is_end()
     }
 }
 

--- a/crates/wysiwyg/src/format_nodes.rs
+++ b/crates/wysiwyg/src/format_nodes.rs
@@ -1,0 +1,401 @@
+use crate::composer_model::{slice, slice_from, slice_to};
+use crate::dom::nodes::{ContainerNodeKind, DomNode, TextNode};
+use crate::dom::{
+    Dom, DomHandle, DomLocation, MultipleNodesRange, Range, SameNodeRange,
+};
+use crate::{ComposerModel, ComposerUpdate, InlineFormatType, UnicodeString};
+
+#[derive(Eq, PartialEq, Debug)]
+enum FormatSelectionType {
+    Extend,
+    Remove,
+}
+
+impl<S> ComposerModel<S>
+where
+    S: UnicodeString,
+{
+    pub fn format(&mut self, format: InlineFormatType) -> ComposerUpdate<S> {
+        // Store current Dom
+        self.push_state_to_history();
+        let (s, e) = self.safe_selection();
+        let range = self.state.dom.find_range(s, e);
+        match range {
+            Range::SameNode(range) => {
+                self.format_same_node(range, format);
+                // TODO: for now, we replace every time, to check ourselves, but
+                // at least some of the time we should not
+                return self.create_update_replace_all();
+            }
+
+            Range::NoNode => {
+                self.state.dom.append_child(DomNode::new_formatting(
+                    format,
+                    vec![DomNode::Text(TextNode::from(S::from_str("")))],
+                ));
+                return ComposerUpdate::keep();
+            }
+
+            Range::MultipleNodes(range) => {
+                self.format_several_nodes(&range, format);
+                return self.create_update_replace_all();
+            }
+        }
+    }
+
+    fn format_same_node(
+        &mut self,
+        range: SameNodeRange,
+        format: InlineFormatType,
+    ) {
+        let node = self.state.dom.lookup_node(range.node_handle.clone());
+        if let DomNode::Text(t) = node {
+            let text = t.data();
+            // TODO: can we be globally smart about not leaving empty text nodes ?
+            let before = slice_to(text, ..range.start_offset);
+            let during = slice(text, range.start_offset..range.end_offset);
+            let after = slice_from(text, range.end_offset..);
+            let new_nodes = vec![
+                DomNode::Text(TextNode::from(before)),
+                DomNode::new_formatting(
+                    format,
+                    vec![DomNode::Text(TextNode::from(during))],
+                ),
+                DomNode::Text(TextNode::from(after)),
+            ];
+            self.state.dom.replace(range.node_handle, new_nodes);
+        } else {
+            panic!("Trying to bold a non-text node")
+        }
+    }
+
+    fn check_format_selection_type(
+        &self,
+        locations: &Vec<DomLocation>,
+        format: InlineFormatType,
+    ) -> FormatSelectionType {
+        // First sweep to understand what the underlying DOM looks like
+        let found_format_locations: Vec<&DomLocation> = locations
+            .iter()
+            .filter(|l| {
+                let node = self.state.dom.lookup_node(l.node_handle.clone());
+                Self::is_format_node(node, format.clone())
+            })
+            .collect();
+
+        // No format nodes found, so it can we can only create new formatting nodes by Extend
+        if found_format_locations.is_empty() {
+            FormatSelectionType::Extend
+        } else {
+            // Find text nodes inside the selection that are not formatted with this format
+            let non_formatted_leaf_locations = locations.iter().filter(|l| {
+                Self::path_contains_format_node(
+                    &self.state.dom,
+                    l.node_handle.clone(),
+                    &format,
+                )
+                .is_none()
+            });
+            // If there are selected non-formatted text nodes, we need to extend the format to them
+            let is_extend = non_formatted_leaf_locations.count() > 0;
+            if is_extend {
+                FormatSelectionType::Extend
+            } else {
+                // Otherwise, we found only format notes partially or totally covered by the
+                // selection, we need to remove formatting in the selection range
+                FormatSelectionType::Remove
+            }
+        }
+    }
+
+    fn format_several_nodes(
+        &mut self,
+        range: &MultipleNodesRange,
+        format: InlineFormatType,
+    ) {
+        let selection_type =
+            self.check_format_selection_type(&range.locations, format.clone());
+
+        // Start from the end so modifications to the dom doesn't conflict with next steps
+        match selection_type {
+            FormatSelectionType::Remove => {} // TODO: actually implement this
+            FormatSelectionType::Extend => self
+                .extend_format_in_multiple_nodes(
+                    range.locations.clone(),
+                    &format,
+                ),
+        }
+    }
+
+    fn needs_format(
+        dom: &Dom<S>,
+        loc: &DomLocation,
+        format: &InlineFormatType,
+    ) -> bool {
+        let handle = loc.node_handle.clone();
+        loc.is_leaf
+            && Self::path_contains_format_node(dom, handle, format).is_none()
+    }
+
+    fn extend_format_in_multiple_nodes(
+        &mut self,
+        locations: Vec<DomLocation>,
+        format: &InlineFormatType,
+    ) {
+        // Go through the locations in reverse order to prevent Dom modification issues
+        for loc in locations.iter().rev() {
+            if Self::needs_format(&self.state.dom, loc, &format) {
+                if let DomNode::Container(parent) = self
+                    .state
+                    .dom
+                    .lookup_node_mut(loc.node_handle.parent_handle())
+                {
+                    let index = loc.node_handle.index_in_parent();
+                    let node = parent.remove_child(index);
+                    // Node completely covered, happy path
+                    if loc.is_covered() {
+                        let format_node =
+                            DomNode::new_formatting(format.clone(), vec![node]);
+                        parent.insert_child(index, format_node);
+                    } else {
+                        let position = if loc.is_start() {
+                            loc.start_offset
+                        } else {
+                            loc.end_offset
+                        };
+                        if let Some((orig, new)) =
+                            Self::split_text_node(node, position)
+                        {
+                            if loc.is_start() {
+                                let new = DomNode::new_formatting(
+                                    format.clone(),
+                                    vec![DomNode::Text(new)],
+                                );
+                                parent.insert_child(index, new);
+                                parent.insert_child(index, DomNode::Text(orig));
+                            } else {
+                                let orig = DomNode::new_formatting(
+                                    format.clone(),
+                                    vec![DomNode::Text(orig)],
+                                );
+                                parent.insert_child(index, DomNode::Text(new));
+                                parent.insert_child(index, orig);
+                            }
+                        } else {
+                            panic!("Node was not a text node so it cannot be split.");
+                        }
+                    }
+                }
+            }
+            // Clean up by removing any empty text nodes and merging formatting nodes
+            self.remove_empty_text_nodes(loc.node_handle.parent_handle());
+            self.merge_formatting_nodes(loc.node_handle.parent_handle());
+        }
+    }
+
+    fn path_contains_format_node(
+        dom: &Dom<S>,
+        handle: DomHandle,
+        format: &InlineFormatType,
+    ) -> Option<DomHandle> {
+        if Self::is_format_node(dom.lookup_node(handle.clone()), format.clone())
+        {
+            Some(handle)
+        } else if handle.has_parent() {
+            let parent_handle = handle.parent_handle();
+            if Self::is_format_node(
+                dom.lookup_node(parent_handle.clone()),
+                format.clone(),
+            ) {
+                Some(parent_handle)
+            } else {
+                Self::path_contains_format_node(dom, parent_handle, format)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn is_format_node(node: &DomNode<S>, format: InlineFormatType) -> bool {
+        if let DomNode::Container(n) = node {
+            if let ContainerNodeKind::Formatting(kind) = n.kind() {
+                if *kind == format {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn split_text_node(
+        node: DomNode<S>,
+        position: usize,
+    ) -> Option<(TextNode<S>, TextNode<S>)> {
+        if let DomNode::Text(text_node) = node {
+            let split_data_orig = slice_to(text_node.data(), ..position);
+            let split_data_new = slice_from(text_node.data(), position..);
+            let mut orig = TextNode::from(split_data_orig);
+            orig.set_handle(text_node.handle());
+            let new = TextNode::from(split_data_new);
+            Some((orig, new))
+        } else {
+            None
+        }
+    }
+
+    fn remove_empty_text_nodes(&mut self, handle: DomHandle) {
+        if let DomNode::Container(parent) =
+            self.state.dom.lookup_node_mut(handle.clone())
+        {
+            let mut indexes_to_remove = Vec::new();
+            let children = parent.children();
+            for child in children.iter().rev() {
+                if let DomNode::Text(n) = child {
+                    if n.data().is_empty() {
+                        indexes_to_remove.push(n.handle().index_in_parent());
+                    }
+                }
+            }
+            for i in indexes_to_remove {
+                parent.remove_child(i);
+            }
+        }
+    }
+
+    fn merge_formatting_nodes(&mut self, parent_handle: DomHandle) {
+        if let DomNode::Container(parent) =
+            self.state.dom.lookup_node_mut(parent_handle.clone())
+        {
+            let children = parent.children();
+            for i in (0..children.len() - 1).rev() {
+                parent.merge_children(i + 1, i);
+            }
+        } else {
+            panic!("Parent node must be a Container.");
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::tests::testutils_composer_model::cm;
+
+    use super::*;
+
+    fn find_range<S: UnicodeString>(model: &ComposerModel<S>) -> Range {
+        let (start, end) = model.get_selection();
+        model.state.dom.find_range(start.into(), end.into())
+    }
+
+    fn find_multiple_range<S: UnicodeString>(
+        model: &ComposerModel<S>,
+    ) -> MultipleNodesRange {
+        let range = find_range(&model);
+        if let Range::MultipleNodes(r) = range {
+            r
+        } else {
+            panic!("Should have been a multiple range node, {:?}", range);
+        }
+    }
+
+    #[test]
+    fn selection_type_extend_if_different_type() {
+        let model = cm("{hello <b>wor}|ld</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Italic,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Extend);
+    }
+
+    #[test]
+    fn selection_type_extending_start() {
+        let model = cm("hell{o <b>w}|orld</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Extend);
+    }
+
+    #[test]
+    fn selection_type_extending_end() {
+        let model = cm("<b>hell{o </b>wor}|ld");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Extend);
+    }
+
+    #[test]
+    fn selection_type_extending_middle() {
+        let model = cm("<b>h{el</b>lo <b>wor}|ld</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Extend);
+    }
+
+    #[test]
+    fn selection_type_remove() {
+        let model = cm("<b>hel{lo </b><b>wor}|ld</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Remove);
+    }
+
+    #[test]
+    fn selection_type_remove_on_start_edge() {
+        let model = cm("{<b>hello </b><b>wor}|ld</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Remove);
+    }
+
+    #[test]
+    fn selection_type_remove_on_ending_edge() {
+        let model = cm("<b>hel{lo </b><b>world}|</b>");
+        let range = find_multiple_range(&model);
+        let selection_type = model.check_format_selection_type(
+            &range.locations,
+            InlineFormatType::Bold,
+        );
+        assert_eq!(selection_type, FormatSelectionType::Remove);
+    }
+
+    #[test]
+    fn formatting_several_nodes_works_with_different_format() {
+        let mut model = cm("{hello <i>wor}|ld</i>");
+        model.format(InlineFormatType::Bold);
+        assert_eq!(
+            model.state.dom.to_string(),
+            "<strong>hello </strong><i><strong>wor</strong>ld</i>"
+        );
+    }
+
+    #[test]
+    fn formatting_several_nodes_works_with_same_format() {
+        let mut model = cm("{hello <b>wor}|ld</b>");
+        model.format(InlineFormatType::Bold);
+        assert_eq!(model.state.dom.to_string(), "<strong>hello world</strong>");
+    }
+
+    #[test]
+    fn formatting_several_nodes_works_with_same_format_rev() {
+        let mut model = cm("|{hello <b>wor}ld</b>");
+        model.format(InlineFormatType::Bold);
+        assert_eq!(model.state.dom.to_string(), "<strong>hello world</strong>");
+    }
+}

--- a/crates/wysiwyg/src/format_type.rs
+++ b/crates/wysiwyg/src/format_type.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone)]
+use crate::UnicodeString;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum InlineFormatType {
     Bold,
     Italic,
@@ -29,6 +31,21 @@ impl InlineFormatType {
             InlineFormatType::StrikeThrough => "del",
             InlineFormatType::Underline => "u",
             InlineFormatType::InlineCode => "code",
+        }
+    }
+}
+
+impl<S: UnicodeString> From<S> for InlineFormatType {
+    fn from(value: S) -> Self {
+        match value.to_utf8().as_str() {
+            "b" | "strong" => InlineFormatType::Bold,
+            "i" | "em" => InlineFormatType::Italic,
+            "del" => InlineFormatType::StrikeThrough,
+            "u" => InlineFormatType::Underline,
+            "code" => InlineFormatType::InlineCode,
+            _ => {
+                panic!("Unknown format type {}", value.to_utf8().as_str());
+            }
         }
     }
 }

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -18,6 +18,7 @@ mod composer_model;
 mod composer_state;
 mod composer_update;
 mod dom;
+mod format_nodes;
 mod format_type;
 mod location;
 mod menu_state;

--- a/crates/wysiwyg/src/node_joiner.rs
+++ b/crates/wysiwyg/src/node_joiner.rs
@@ -109,8 +109,7 @@ where
         let cur_handle = DomHandle::from_raw(handle.raw()[..level].to_vec());
         let index_in_parent = cur_handle.index_in_parent();
         if index_in_parent > 0 {
-            let prev_handle =
-                cur_handle.parent_handle().child_handle(index_in_parent - 1);
+            let prev_handle = cur_handle.prev_sibling();
             if let (
                 DomNode::Container(prev_node),
                 DomNode::Container(next_node),

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -36,19 +36,19 @@ pub fn a<'a>(
 pub fn b<'a>(
     children: impl IntoIterator<Item = &'a DomNode<Utf16String>>,
 ) -> DomNode<Utf16String> {
-    DomNode::new_formatting(utf16("b"), clone_children(children))
+    DomNode::new_formatting_from_tag(utf16("b"), clone_children(children))
 }
 
 pub fn i<'a>(
     children: impl IntoIterator<Item = &'a DomNode<Utf16String>>,
 ) -> DomNode<Utf16String> {
-    DomNode::new_formatting(utf16("i"), clone_children(children))
+    DomNode::new_formatting_from_tag(utf16("i"), clone_children(children))
 }
 
 pub fn i_c<'a>(
     children: impl IntoIterator<Item = &'a DomNode<Utf16String>>,
 ) -> DomNode<Utf16String> {
-    DomNode::new_formatting(utf16("code"), clone_children(children))
+    DomNode::new_formatting_from_tag(utf16("code"), clone_children(children))
 }
 
 fn clone_children<'a>(


### PR DESCRIPTION
What this PR does:

* Separates formatting nodes into a separate file.
* Adds `ComposerModel.check_format_selection_type` fn that returns `Extend` to create new formatting nodes and `Remove` to remove them.
* `find_range` returns all intersections with other nodes, including parents of the text nodes. There is a workaround for SameRangeNode where we check that there's only 1 'leaf node' (that is, one text node right now).
* Added several extra properties to `DomLocation` such as _position, length, is_leaf_. Also added some extra functions to check if it's the start or the end of the selection and if the selection completely covers it, as well as next and prev sibling generator.
* Adding formatting nodes when `check_format_selection_type` returns `Extend` is supported, removing them when it returns `Remove` is left as a to-do.

There might also be some conflicting parts: I created a `merge_children` function on `ContainerNode` to merge sibling children of the same type, then created a helper `ComposerModel.merge_formatting_nodes` function that uses it. Recently we added a `NodeJoiner`, I need to check if these 2 functions do the same and if they do, which one we should keep (or both).