### PR TITLE
Improve list location handling & separate list actions from main model file

### DIFF
--- a/crates/wysiwyg/src/composer_list_handler.rs
+++ b/crates/wysiwyg/src/composer_list_handler.rs
@@ -36,6 +36,9 @@ where
         location: usize,
         range: SameNodeRange,
     ) -> ComposerUpdate<S> {
+        // do_enter_in_list should only be called on a single location
+        // as selection can be deleted beforehand.
+        assert_eq!(range.start_offset, range.end_offset);
         // Store current Dom
         self.push_state_to_history();
         let parent_node = self.state.dom.lookup_node(parent_handle.clone());
@@ -106,7 +109,6 @@ where
         location: usize,
         range: SameNodeRange,
     ) {
-        assert_eq!(range.start_offset, range.end_offset);
         let text_node = self.state.dom.lookup_node_mut(range.node_handle);
         if let DomNode::Text(ref mut t) = text_node {
             let text = t.data();
@@ -177,7 +179,7 @@ where
                         self.state.start = new_location;
                         self.state.end = new_location;
                     } else {
-                        panic!("List has no parent container")
+                        panic!("Parent node is not a container")
                     }
                 } else {
                     let new_location = Location::from(location - li_len);

--- a/crates/wysiwyg/src/composer_list_handler.rs
+++ b/crates/wysiwyg/src/composer_list_handler.rs
@@ -1,0 +1,190 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::composer_model::{slice_from, slice_to};
+use crate::dom::nodes::{ContainerNode, DomNode, TextNode};
+use crate::dom::to_raw_text::ToRawText;
+use crate::dom::{DomHandle, Range, SameNodeRange};
+use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
+
+impl<S> ComposerModel<S>
+where
+    S: UnicodeString,
+{
+    pub fn create_ordered_list(&mut self) -> ComposerUpdate<S> {
+        self.create_list(true)
+    }
+
+    pub fn create_unordered_list(&mut self) -> ComposerUpdate<S> {
+        self.create_list(false)
+    }
+
+    pub(crate) fn do_enter_in_list(
+        &mut self,
+        parent_handle: DomHandle,
+        location: usize,
+        range: SameNodeRange,
+    ) -> ComposerUpdate<S> {
+        // Store current Dom
+        self.push_state_to_history();
+        let parent_node = self.state.dom.lookup_node(parent_handle.clone());
+        let list_node_handle = parent_node.handle().parent_handle();
+        if let DomNode::Container(parent) = parent_node {
+            if parent.is_empty_list_item() {
+                self.remove_list_item(
+                    list_node_handle,
+                    location,
+                    parent_handle.index_in_parent(),
+                    true,
+                );
+            } else {
+                self.slice_list_item(list_node_handle, location, range);
+            }
+            self.create_update_replace_all()
+        } else {
+            panic!("No list item found")
+        }
+    }
+
+    fn create_list(&mut self, ordered: bool) -> ComposerUpdate<S> {
+        // Store current Dom
+        self.push_state_to_history();
+        let list_tag = if ordered { "ol" } else { "ul" };
+        let (s, e) = self.safe_selection();
+        let range = self.state.dom.find_range(s, e);
+        match range {
+            Range::SameNode(range) => {
+                let node =
+                    self.state.dom.lookup_node(range.node_handle.clone());
+                if let DomNode::Text(t) = node {
+                    let text = t.data();
+                    let list_node = DomNode::new_list(
+                        S::from_str(list_tag),
+                        vec![DomNode::Container(ContainerNode::new_list_item(
+                            S::from_str("li"),
+                            vec![DomNode::Text(TextNode::from(text.clone()))],
+                        ))],
+                    );
+                    self.state.dom.replace(range.node_handle, vec![list_node]);
+                    return self.create_update_replace_all();
+                } else {
+                    panic!("Can't create a list from a non-text node")
+                }
+            }
+
+            Range::NoNode => {
+                self.state.dom.append_child(DomNode::new_list(
+                    S::from_str(list_tag),
+                    vec![DomNode::Container(ContainerNode::new_list_item(
+                        S::from_str("li"),
+                        vec![DomNode::Text(TextNode::from(S::from_str("")))],
+                    ))],
+                ));
+                return self.create_update_replace_all();
+            }
+
+            _ => {
+                panic!("Can't create ordered list in complex object models yet")
+            }
+        }
+    }
+
+    fn slice_list_item(
+        &mut self,
+        handle: DomHandle,
+        location: usize,
+        range: SameNodeRange,
+    ) {
+        assert_eq!(range.start_offset, range.end_offset);
+        let text_node = self.state.dom.lookup_node_mut(range.node_handle);
+        if let DomNode::Text(ref mut t) = text_node {
+            let text = t.data();
+            // TODO: should slice container nodes between li and text node as well
+            let new_text = slice_to(text, ..range.start_offset);
+            let new_li_text = slice_from(text, range.end_offset..);
+            t.set_data(new_text);
+            let list_node = self.state.dom.lookup_node_mut(handle);
+            if let DomNode::Container(list) = list_node {
+                let add_zwsp = new_li_text.len() == 0;
+                list.append_child(DomNode::new_list_item(
+                    S::from_str("li"),
+                    vec![DomNode::Text(TextNode::from(if add_zwsp {
+                        S::from_str("\u{200B}")
+                    } else {
+                        new_li_text
+                    }))],
+                ));
+                if add_zwsp {
+                    self.state.start = Location::from(location + 1);
+                    self.state.end = Location::from(location + 1);
+                }
+            }
+        }
+    }
+
+    fn remove_list_item(
+        &mut self,
+        list_handle: DomHandle,
+        location: usize,
+        li_index: usize,
+        insert_trailing_text_node: bool,
+    ) {
+        let list_node = self.state.dom.lookup_node_mut(list_handle.clone());
+        if let DomNode::Container(list) = list_node {
+            let list_len = list.to_raw_text().len();
+            let li_len = list.children()[li_index].to_raw_text().len();
+            if list.children().len() == 1 {
+                let parent_handle = list_handle.parent_handle();
+                let parent_node = self.state.dom.lookup_node_mut(parent_handle);
+                if let DomNode::Container(parent) = parent_node {
+                    parent.remove_child(list_handle.index_in_parent());
+                    if parent.children().len() == 0 {
+                        parent.append_child(DomNode::Text(TextNode::from(
+                            S::from_str(""),
+                        )));
+                    }
+                    let new_location = Location::from(location - list_len);
+                    self.state.start = new_location;
+                    self.state.end = new_location;
+                } else {
+                    // TODO: handle list items outside of lists
+                    panic!("List has no parent container")
+                }
+            } else {
+                list.remove_child(li_index);
+                if insert_trailing_text_node {
+                    let parent_handle = list_handle.parent_handle();
+                    let parent_node =
+                        self.state.dom.lookup_node_mut(parent_handle);
+                    if let DomNode::Container(parent) = parent_node {
+                        // TODO: should probably append a paragraph instead
+                        parent.append_child(DomNode::Text(TextNode::from(
+                            S::from_str("\u{200B}"),
+                        )));
+                        let new_location =
+                            Location::from(location - li_len + 1);
+                        self.state.start = new_location;
+                        self.state.end = new_location;
+                    } else {
+                        panic!("List has no parent container")
+                    }
+                } else {
+                    let new_location = Location::from(location - li_len);
+                    self.state.start = new_location;
+                    self.state.end = new_location;
+                }
+            }
+        }
+    }
+}

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod composer_action;
+mod composer_list_handler;
 mod composer_model;
 mod composer_state;
 mod composer_update;

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -22,7 +22,7 @@ use crate::tests::testutils_conversion::utf16;
 use crate::ComposerModel;
 
 #[test]
-fn test_ordered_list() {
+fn creating_ordered_list_and_writing() {
     let mut model = cm("|");
     model.create_ordered_list();
     assert_eq!(tx(&model), "<ol><li>|</li></ol>");
@@ -35,21 +35,51 @@ fn test_ordered_list() {
 }
 
 #[test]
-fn test_unordered_list() {
+fn creating_unordered_list() {
     let mut model = cm("|");
     model.create_unordered_list();
     assert_eq!(tx(&model), "<ul><li>|</li></ul>");
 }
 
 #[test]
-fn test_removing_list_item() {
+fn removing_list_item() {
     let mut model = cm("<ol><li>abcd</li><li>\u{200b}|</li></ol>");
     model.enter();
     assert_eq!(tx(&model), "<ol><li>abcd</li></ol>\u{200b}|");
 }
 
 #[test]
-fn test_removing_list() {
+fn entering_with_entire_selection() {
+    let mut model = cm("<ol><li>{abcd}|</li></ol>");
+    model.enter();
+    assert_eq!(tx(&model), "|");
+}
+
+#[test]
+fn entering_with_entire_selection_with_formatting() {
+    let mut model = cm("<ol><li><b>{abcd}|</b></li></ol>");
+    model.enter();
+    assert_eq!(tx(&model), "|");
+}
+
+#[test]
+fn entering_mid_text_node() {
+    let mut model = cm("<ol><li>ab|gh</li></ol>");
+    model.enter();
+    // FIXME: selection should be before the first char of second node
+    assert_eq!(tx(&model), "<ol><li>ab|</li><li>gh</li></ol>");
+}
+
+#[test]
+fn entering_mid_text_node_with_selection() {
+    let mut model = cm("<ol><li>ab{cdef}|gh</li></ol>");
+    model.enter();
+    // FIXME: selection should be before the first char of second node
+    assert_eq!(tx(&model), "<ol><li>ab|</li><li>gh</li></ol>");
+}
+
+#[test]
+fn removing_list() {
     let mut model = cm("|");
     model.create_ordered_list();
     model.enter();


### PR DESCRIPTION
* Move composer_model lists handling to a separate file
* Handle enter() when the selection length is > 0
* Handle slicing when enter() in a text node contained in a list item