### PR TITLE
Implement merging algorithm for structure and formatting nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -299,7 +299,7 @@ where
         self.delete_nodes(to_delete);
 
         let pos: usize = self.state.start.into();
-        node_joiner.join_nodes(&mut self.state.dom, pos + len);
+        node_joiner.join_nodes(&mut self.state.dom, pos + len + 1);
     }
 
     /// Given a range to replace and some new text, modify the nodes in the

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -30,19 +30,6 @@ where
     handle: DomHandle,
 }
 
-impl<S> ContainerNode<S>
-where
-    S: UnicodeString,
-{
-    pub(crate) fn is_structure_node(&self) -> bool {
-        match self.kind {
-            ContainerNodeKind::List(_) | ContainerNodeKind::ListItem() => true,
-            ContainerNodeKind::Formatting(_) => true,
-            _ => false,
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub enum ContainerNodeKind<S>
 where
@@ -179,9 +166,27 @@ where
         &self.children
     }
 
+    pub fn kind(&self) -> &ContainerNodeKind<S> {
+        &self.kind
+    }
+
     pub fn is_list_item(&self) -> bool {
         match self.kind {
             ContainerNodeKind::ListItem() => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_structure_node(&self) -> bool {
+        match self.kind {
+            ContainerNodeKind::List(_) | ContainerNodeKind::ListItem() => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_formatting_node(&self) -> bool {
+        match self.kind {
+            ContainerNodeKind::Formatting(_) => true,
             _ => false,
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -30,6 +30,19 @@ where
     handle: DomHandle,
 }
 
+impl<S> ContainerNode<S>
+where
+    S: UnicodeString,
+{
+    pub(crate) fn is_structure_node(&self) -> bool {
+        match self.kind {
+            ContainerNodeKind::List(_) | ContainerNodeKind::ListItem() => true,
+            ContainerNodeKind::Formatting(_) => true,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ContainerNodeKind<S>
 where

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -71,6 +71,13 @@ where
     pub fn new_link(url: S, children: Vec<DomNode<S>>) -> DomNode<S> {
         DomNode::Container(ContainerNode::new_link(url, children))
     }
+
+    pub fn is_structure_node(&self) -> bool {
+        match self {
+            DomNode::Container(n) => n.is_structure_node(),
+            _ => false,
+        }
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -78,6 +78,13 @@ where
             _ => false,
         }
     }
+
+    pub fn is_formatting_node(&self) -> bool {
+        match self {
+            DomNode::Container(n) => n.is_formatting_node(),
+            _ => false,
+        }
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/node_joiner.rs
+++ b/crates/wysiwyg/src/node_joiner.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 
 use crate::dom::nodes::{ContainerNodeKind, DomNode, TextNode};
 use crate::dom::{Dom, DomHandle, DomLocation, MultipleNodesRange, Range};
-use crate::{ToHtml, UnicodeString};
+use crate::UnicodeString;
 
 /// Handles joining together nodes after an edit event.
 ///
@@ -92,7 +92,7 @@ where
     }
 
     fn join_format_nodes(&self, dom: &mut Dom<S>, new_pos: usize) {
-        if let Some(mut next_node_handle) = Self::find_next_node(dom, new_pos) {
+        if let Some(next_node_handle) = Self::find_next_node(dom, new_pos) {
             self.join_format_nodes_at_level(dom, next_node_handle, 1);
         }
     }
@@ -222,7 +222,6 @@ where
                     if let DomNode::Container(parent) =
                         dom.lookup_node_mut(start_handle.parent_handle())
                     {
-                        let mut parent = parent;
                         parent.replace_child(
                             start_handle.index_in_parent(),
                             vec![text_node],
@@ -325,99 +324,6 @@ where
         ancestors
     }
 
-    fn join_nodes_of_same_type(dom: &mut Dom<S>, new_pos: usize) {
-        let new_range = dom.find_range(new_pos, new_pos);
-
-        if let Range::SameNode(new_range) = new_range {
-            // Find the text node we are in now the selection has been deleted
-            let current_text = new_range.node_handle;
-
-            // Find the container node that contains us e.g. <b>. This is
-            // what we are going to join with something else>
-            let current_container = current_text.parent_handle();
-
-            // Find the parent that contains both the <b> tags that we are
-            // going to join.
-            let parent = current_container.parent_handle();
-
-            // Look for our sibling container - e.g. the other <b>
-            // TODO: check we have a sibling instead of crashing here
-            let sibling =
-                parent.child_handle(current_container.index_in_parent() + 1);
-
-            Self::join_nodes_using_handles(dom, parent, current_text, sibling);
-        } else {
-            // We won't get here until we delete SameNode, or allow pasting
-            // HTML formatted text
-            panic!(
-                "Not set up for MultipleNodeRange, but we could use
-                   first_text_handle here to get the right node I think."
-            );
-        }
-    }
-
-    fn join_nodes_using_handles(
-        dom: &mut Dom<S>,
-        parent: DomHandle,
-        current_text: DomHandle,
-        sibling: DomHandle,
-    ) {
-        let sibling_node = dom.lookup_node(sibling.clone());
-        if let DomNode::Container(_) = sibling_node {
-            let sibling_text = sibling.child_handle(0);
-            let sibling_text_node = dom.lookup_node(sibling_text);
-            if let DomNode::Text(second_text_node) = sibling_text_node {
-                let remaining_text = second_text_node.data().clone();
-                Self::do_join_nodes(
-                    dom,
-                    parent,
-                    current_text,
-                    sibling,
-                    remaining_text,
-                );
-            } else {
-                // TODO: The first node in the sibling container was not text.
-                // We should probably just combine the children, but bailing
-                // out for now.
-            }
-        } else {
-            // TODO: Sibling is a text node - should probably join to
-            // it, but bailing out for now.
-        }
-    }
-
-    fn is_container(dom: &Dom<S>, handle: &DomHandle) -> bool {
-        matches!(dom.lookup_node(handle.clone()), DomNode::Container(_))
-    }
-
-    /// Actually join the nodes: delete the sibling, and append its text onto
-    /// our current text node.
-    fn do_join_nodes(
-        dom: &mut Dom<S>,
-        parent: DomHandle,
-        current_text: DomHandle,
-        sibling: DomHandle,
-        remaining_text: S,
-    ) {
-        // Delete the sibling's container
-        let parent_node = dom.lookup_node_mut(parent);
-        if let DomNode::Container(parent_node) = parent_node {
-            parent_node.remove_child(sibling.index_in_parent())
-        } else {
-            panic!("Parent was not a container!");
-        }
-
-        // Add the remaining text to this node
-        let current_text = dom.lookup_node_mut(current_text);
-        if let DomNode::Text(current_text) = current_text {
-            let mut new_data = current_text.data().clone();
-            new_data.push_string(&remaining_text);
-            current_text.set_data(new_data);
-        } else {
-            panic!("Current text was not text!");
-        }
-    }
-
     /// Search the supplied iterator for a text node and return a handle to it,
     /// or None if there are no text nodes.
     fn find_text_handle<'a>(
@@ -438,23 +344,5 @@ where
         range: &MultipleNodesRange,
     ) -> Option<DomHandle> {
         Self::find_text_handle(dom, range.locations.iter())
-    }
-
-    fn last_text_handle(
-        dom: &Dom<S>,
-        range: &MultipleNodesRange,
-    ) -> Option<DomHandle> {
-        Self::find_text_handle(dom, range.locations.iter().rev())
-    }
-
-    /// Panics if this handle does not refer to something with a parent
-    fn parent_container_type(dom: &Dom<S>, handle: DomHandle) -> String {
-        let parent = handle.parent_handle();
-        let node = dom.lookup_node(parent);
-        if let DomNode::Container(node) = node {
-            node.name().to_utf8()
-        } else {
-            panic!("Expected parent to be a container node");
-        }
     }
 }

--- a/crates/wysiwyg/src/node_joiner.rs
+++ b/crates/wysiwyg/src/node_joiner.rs
@@ -14,7 +14,7 @@
 
 use std::marker::PhantomData;
 
-use crate::dom::nodes::DomNode;
+use crate::dom::nodes::{DomNode, TextNode};
 use crate::dom::{Dom, DomHandle, DomLocation, MultipleNodesRange, Range};
 use crate::UnicodeString;
 
@@ -27,10 +27,8 @@ pub(crate) struct NodeJoiner<S>
 where
     S: UnicodeString,
 {
-    first_type: Option<String>,
-    last_type: Option<String>,
+    start_handle: DomHandle,
 
-    /// This is just to allow us to have the S generic param
     phantom_data: PhantomData<S>,
 }
 
@@ -48,15 +46,11 @@ where
         // that demonstrate that this is not good enough. We need to consider
         // joining nodes all the way up the tree.
 
-        let first_type = Self::first_text_handle(dom, range)
-            .map(|h| Self::parent_container_type(dom, h));
-
-        let last_type = Self::last_text_handle(dom, range)
-            .map(|h| Self::parent_container_type(dom, h));
+        let start_handle = Self::first_text_handle(dom, range)
+            .expect("No start text node found");
 
         Self {
-            first_type,
-            last_type,
+            start_handle,
             phantom_data: PhantomData::default(),
         }
     }
@@ -64,16 +58,193 @@ where
     /// After the selection range we were given in from_range has been deleted,
     /// join any nodes that match up across the selection.
     pub(crate) fn join_nodes(&self, dom: &mut Dom<S>, new_pos: usize) {
-        match (self.first_type.as_ref(), self.last_type.as_ref()) {
-            (Some(first_type), Some(last_type)) => {
-                if first_type == last_type {
-                    // The selection started and ended in the same type of
-                    // node - we should join these 2 tags.
-                    Self::join_nodes_of_same_type(dom, new_pos)
+        // Find next node
+        if let Some(mut next_handle) = Self::find_next_node(dom, new_pos) {
+            // Find struct parents
+            if let (Some(struct_parent_start), Some(struct_parent_next)) =
+                Self::find_struct_parents(dom, &self.start_handle, &next_handle)
+            {
+                if struct_parent_start != struct_parent_next {
+                    // Move children
+                    let new_index = Self::move_children(
+                        dom,
+                        &struct_parent_next,
+                        &struct_parent_start,
+                    );
+
+                    next_handle = struct_parent_start.child_handle(new_index);
                 }
+
+                // Find ancestor lists
+                let ancestors_start =
+                    Self::find_ancestor_list(&self.start_handle);
+                let ancestors_next = Self::find_ancestor_list(&next_handle);
+
+                // Merge nodes based on ancestors
+                Self::do_join(dom, &ancestors_start, &ancestors_next);
             }
-            _ => {}
         }
+    }
+
+    fn do_join(
+        dom: &mut Dom<S>,
+        ancestors_start: &Vec<DomHandle>,
+        ancestors_next: &Vec<DomHandle>,
+    ) {
+        let mut i = 0;
+        let mut j = 0;
+        while i < ancestors_start.len() && j < ancestors_next.len() {
+            let start_handle = ancestors_start.get(i).unwrap();
+            let next_handle = ancestors_next.get(j).unwrap();
+
+            // If both lists contain this ancestor handle, continue to the next comparison.
+            if start_handle == next_handle {
+                i += 1;
+                j += 1;
+                continue;
+            }
+
+            let start_i = dom.lookup_node(start_handle.clone());
+            let next_i = dom.lookup_node(next_handle.clone());
+
+            match (start_i, next_i) {
+                (DomNode::Container(start_i), DomNode::Container(next_i)) => {
+                    if start_i.name() == next_i.name() {
+                        // Both containers with the same tag.
+                        // Move children from next to start node, remove next node.
+                        let new_index_in_parent =
+                            Self::move_children(dom, next_handle, start_handle);
+                        // This alters ancestors, so we need to re-calculate them and start again.
+                        // TODO: maybe move this to another fn?
+                        let mut new_next_path =
+                            start_handle.raw()[..i].to_vec();
+                        new_next_path.push(new_index_in_parent);
+                        let new_next_handle =
+                            DomHandle::from_raw(new_next_path);
+
+                        // Re-calculate ancestors
+                        let new_ancestors_next =
+                            Self::find_ancestor_list(&new_next_handle);
+                        // Restart the process
+                        Self::do_join(
+                            dom,
+                            ancestors_start,
+                            &new_ancestors_next,
+                        );
+                        return;
+                    } else {
+                        // Both containers, but different tags. We're done.
+                        return;
+                    }
+                }
+                (DomNode::Text(start_i), DomNode::Text(next_i)) => {
+                    let mut new_data = start_i.data().clone();
+                    new_data.push_string(&next_i.data());
+                    let text_node = DomNode::Text(TextNode::from(new_data));
+                    if let DomNode::Container(parent) =
+                        dom.lookup_node_mut(start_handle.parent_handle())
+                    {
+                        parent.remove_child(next_handle.index_in_parent());
+                        parent.replace_child(
+                            start_handle.index_in_parent(),
+                            vec![text_node],
+                        );
+                    }
+                    return;
+                }
+                _ => return,
+            }
+        }
+    }
+
+    fn find_next_node(dom: &Dom<S>, pos: usize) -> Option<DomHandle> {
+        let new_range = dom.find_range(pos, pos);
+        if let Range::SameNode(r) = new_range {
+            Some(r.node_handle)
+        } else {
+            None
+        }
+    }
+
+    fn find_struct_parents(
+        dom: &Dom<S>,
+        start: &DomHandle,
+        next: &DomHandle,
+    ) -> (Option<DomHandle>, Option<DomHandle>) {
+        let struct_parent_start = Self::find_struct_parent(dom, start);
+        let struct_parent_next = Self::find_struct_parent(dom, next);
+        (struct_parent_start, struct_parent_next)
+    }
+
+    fn find_struct_parent(
+        dom: &Dom<S>,
+        handle: &DomHandle,
+    ) -> Option<DomHandle> {
+        let parent_handle = handle.parent_handle();
+        let parent = dom.lookup_node(parent_handle.clone());
+        if parent.is_structure_node() && parent_handle.has_parent() {
+            if let Some(parent_result) =
+                Self::find_struct_parent(dom, &parent_handle)
+            {
+                Some(parent_result)
+            } else {
+                Some(parent_handle)
+            }
+        } else if parent_handle.has_parent() {
+            Self::find_struct_parent(dom, &parent_handle)
+        } else {
+            None
+        }
+    }
+
+    fn move_children(
+        dom: &mut Dom<S>,
+        from_handle: &DomHandle,
+        to_handle: &DomHandle,
+    ) -> usize {
+        let ret;
+        let children = if let DomNode::Container(from_node) =
+            dom.lookup_node(from_handle.clone())
+        {
+            from_node.children().clone()
+        } else {
+            panic!("Source node must be a ContainerNode");
+        };
+
+        if let DomNode::Container(to_node) =
+            dom.lookup_node_mut(to_handle.clone())
+        {
+            ret = to_node.children().len();
+            for c in children {
+                to_node.append_child(c)
+            }
+        } else {
+            panic!("Destination node must be a ContainerNode");
+        }
+
+        if let DomNode::Container(parent) =
+            dom.lookup_node_mut(from_handle.parent_handle())
+        {
+            parent.remove_child(from_handle.index_in_parent());
+        } else {
+            panic!("Previous parent of source node must be a ContainerNode");
+        }
+
+        ret
+    }
+
+    fn find_ancestor_list(handle: &DomHandle) -> Vec<DomHandle> {
+        let mut ancestors = Vec::new();
+        let mut cur_handle = handle.clone();
+        while cur_handle.has_parent() {
+            ancestors.push(cur_handle.clone());
+            cur_handle = cur_handle.parent_handle();
+        }
+        // Root node
+        ancestors.push(DomHandle::from_raw(Vec::new()));
+        // Reverse to start from root
+        ancestors.reverse();
+        ancestors
     }
 
     fn join_nodes_of_same_type(dom: &mut Dom<S>, new_pos: usize) {
@@ -135,6 +306,10 @@ where
             // TODO: Sibling is a text node - should probably join to
             // it, but bailing out for now.
         }
+    }
+
+    fn is_container(dom: &Dom<S>, handle: &DomHandle) -> bool {
+        matches!(dom.lookup_node(handle.clone()), DomNode::Container(_))
     }
 
     /// Actually join the nodes: delete the sibling, and append its text onto

--- a/crates/wysiwyg/src/node_joiner.rs
+++ b/crates/wysiwyg/src/node_joiner.rs
@@ -137,6 +137,9 @@ where
                         return;
                     }
                 }
+                (DomNode::Container(_), DomNode::Text(_)) => {
+                    i += 1;
+                }
                 (DomNode::Text(start_i), DomNode::Text(next_i)) => {
                     let mut new_data = start_i.data().clone();
                     new_data.push_string(&next_i.data());

--- a/crates/wysiwyg/src/node_joiner.rs
+++ b/crates/wysiwyg/src/node_joiner.rs
@@ -185,16 +185,11 @@ where
                         let new_index_in_parent =
                             Self::move_children(dom, next_handle, start_handle);
                         // This alters ancestors, so we need to re-calculate them and start again.
-                        // TODO: maybe move this to another fn?
-                        let mut new_next_path =
-                            start_handle.raw()[..i].to_vec();
-                        new_next_path.push(new_index_in_parent);
-                        let new_next_handle =
-                            DomHandle::from_raw(new_next_path);
-
-                        // Re-calculate ancestors
-                        let new_ancestors_next =
-                            Self::find_ancestor_list(&new_next_handle);
+                        let new_ancestors_next = Self::re_calculate_ancestors(
+                            start_handle,
+                            new_index_in_parent,
+                            i,
+                        );
                         // Restart the process
                         Self::do_join(
                             dom,
@@ -232,6 +227,19 @@ where
                 _ => return,
             }
         }
+    }
+
+    fn re_calculate_ancestors(
+        start_handle: &DomHandle,
+        new_index_in_parent: usize,
+        level: usize,
+    ) -> Vec<DomHandle> {
+        let mut new_next_path = start_handle.raw()[..level].to_vec();
+        new_next_path.push(new_index_in_parent);
+        let new_next_handle = DomHandle::from_raw(new_next_path);
+
+        // Re-calculate ancestors
+        Self::find_ancestor_list(&new_next_handle)
     }
 
     fn find_next_node(dom: &Dom<S>, pos: usize) -> Option<DomHandle> {

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -18,7 +18,6 @@ use widestring::Utf16String;
 
 use crate::tests::testutils_composer_model::{cm, tx};
 use crate::tests::testutils_conversion::utf16;
-
 use crate::{ComposerModel, Location};
 
 #[test]
@@ -138,11 +137,10 @@ fn typing_a_character_when_spanning_two_separate_identical_tags_joins_them() {
 }
 
 #[test]
-#[ignore = "TODO Fails because it crashes with an invalid handle"]
 fn typing_a_character_can_join_the_parents_and_grandparents() {
     let mut model = cm("<b>BB<i>II{II</i>BB</b> gap <b>CC<i>JJ}|JJ</i>CC</b>");
     replace_text(&mut model, "_");
-    assert_eq!(tx(&model), "<b>BB<i>II_JJ</i>CC</b>");
+    assert_eq!(tx(&model), "<b>BB<i>II_|JJ</i>CC</b>");
 }
 
 #[test]
@@ -206,7 +204,6 @@ fn replacing_across_list_items_deletes_intervening_ones() {
 }
 
 #[test]
-#[ignore = "TODO Fails because it leaves 2 different lists"]
 fn replacing_across_lists_joins_them() {
     let mut model = cm("<ol>
             <li>1{1</li>
@@ -217,7 +214,12 @@ fn replacing_across_lists_joins_them() {
             <li>4}|4</li>
         </ol>");
     replace_text(&mut model, "Z");
-    assert_eq!(tx(&model), "<ol><li>1Z4</li></ol>");
+    assert_eq!(
+        tx(&model),
+        "<ol>
+            <li>1Z|4</li>
+        </ol>"
+    );
 }
 
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -135,3 +135,39 @@ fn deleting_across_lists_joins_them() {
         </ol>"
     );
 }
+
+#[test]
+fn deleting_across_lists_joins_them_nested() {
+    let mut model = cm("<ol>
+            <li>1{1</li>
+            <li>22</li>
+            <ol>
+                <li>55</li>
+            </ol>
+        </ol>
+        <ol>
+            <li>33</li>
+            <li>4}|4</li>
+        </ol>");
+    model.delete();
+    assert_eq!(
+        tx(&model),
+        "<ol>
+            <li>1|4</li>
+        </ol>"
+    );
+}
+
+#[test]
+fn deleting_across_formatting_different_types() {
+    let mut model = cm("<b><i>some {italic</i></b> and}| <b>bold</b> text");
+    model.delete();
+    assert_eq!(tx(&model), "<b><i>some |</i></b> <b>bold</b> text");
+}
+
+#[test]
+fn deleting_across_formatting_different_types_on_node_boundary() {
+    let mut model = cm("<b><i>some {italic</i></b> and }|<b>bold</b> text");
+    model.delete();
+    assert_eq!(tx(&model), "<b><i>some |</i>bold</b> text");
+}

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -118,7 +118,6 @@ fn deleting_across_list_items_joins_them() {
 }
 
 #[test]
-#[ignore = "TODO Fails because of an invalid handle"]
 fn deleting_across_lists_joins_them() {
     let mut model = cm("<ol>
             <li>1{1</li>
@@ -129,5 +128,10 @@ fn deleting_across_lists_joins_them() {
             <li>4}|4</li>
         </ol>");
     model.delete();
-    assert_eq!(tx(&model), "<ol><li>14</li></ol>");
+    assert_eq!(
+        tx(&model),
+        "<ol>
+            <li>1|4</li>
+        </ol>"
+    );
 }

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -171,3 +171,10 @@ fn deleting_across_formatting_different_types_on_node_boundary() {
     model.delete();
     assert_eq!(tx(&model), "<b><i>some |</i>bold</b> text");
 }
+
+#[test]
+fn deleting_in_nested_structure_and_format_nodes_works() {
+    let mut model = cm("<ul><li>A</li><li><b>B{B</b><b>C}|C</b></li></ul>");
+    model.delete();
+    assert_eq!(tx(&model), "<ul><li>A</li><li><b>B|C</b></li></ul>");
+}


### PR DESCRIPTION
Implemented the algorithm that @andybalaam proposed for structure nodes + a simpler one for formatting nodes:

<details>
  <summary>See structure nodes merging algorithm</summary>
There are 4 types of tag:

* structural e.g.  `<ul>, <li>, <div>`
* block formatting e.g. blockquote, code blocks
* inline formatting e.g. `<b>, <em>`
* items e.g. `<a>`

This logic should go into NodeJoiner (which is in PR #46).

1. This only applies if our selection spans multiple nodes. If we're in one node, don't do anything.
2. Remember the start text node of the selection.  Call it S.
3. Go ahead and do the replace_text, so some nodes will get deleted, but our start text node still exists.
4. Find the next text node after our start text node. Call it N. (It will probably have at least 1 character in it, so we can probably just look for the text node which corresponds to the position 1 code unit further forward.)
5. Find the lowest-level structural tag ancestor of S and N - call them struct_parent(S) and struct_parent(N). Join struct_parent(N) into struct_parent(S) - remove all struct_parent(N)'s children and add them to struct_parent(S).
6. For both S and N, find their entire ancestor list (including themself), and sort it so that the root is first.
7. Step through S and N's ancestor lists in lock-step (root first):
a. if this ancestor is also in N's ancestor list, move forward in both lists
b. if they are both containers, and their tags are the same, join them and continue stepping through the lists. To join them, append all the children of the N ancestor to the S ancestor, and delete the N ancestor. Adjust the N's ancestor list so it refers to the nodes even though they moved.
c. if they are both containers but with different tags, stop. We are done.
d. if S's ancestor is a container but N's is text (i.e. it is actually N), step forward in S's list, but not N's, so next step we will compare S's next ancestor with N again. Continue stepping.
e. if S's ancestor is text (i.e. it's S) but N's is a container, stop. We are done.
f. if both are text (i.e. we're looking at S and N) then join them: append N's text to S, and delete N. We are done.
Note: it's probably easier actually to sort the ancestors so root is first, and pop them off the list as we process them.
</summary>
</details>

For merging formatting nodes, we search for the next node again and from the root we go down the tree comparing the next node at different levels and its previous sibling, if they match, we merge.