### PR TITLE
Remove redundant node merging strategies

### DIFF
--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -215,13 +215,11 @@ where
         new_text: S,
     ) {
         let len = new_text.len();
-        let node_joiner = NodeJoiner::from_range(&self.state.dom, &range);
-
-        let to_delete = self.replace_in_text_nodes(range, new_text);
+        let to_delete = self.replace_in_text_nodes(range.clone(), new_text);
         self.delete_nodes(to_delete);
 
         let pos: usize = self.state.start.into();
-        node_joiner.join_nodes(&mut self.state.dom, pos + len + 1);
+        NodeJoiner::join_nodes(&mut self.state.dom, &range, pos + len + 1);
     }
 
     /// Given a range to replace and some new text, modify the nodes in the

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -70,11 +70,15 @@ where
         self.document().children()
     }
 
-    pub fn append_child(&mut self, child: DomNode<S>) {
+    pub fn append_child(&mut self, child: DomNode<S>) -> DomHandle {
         self.document_mut().append_child(child)
     }
 
-    pub fn replace(&mut self, node_handle: DomHandle, nodes: Vec<DomNode<S>>) {
+    pub fn replace(
+        &mut self,
+        node_handle: DomHandle,
+        nodes: Vec<DomNode<S>>,
+    ) -> Vec<DomHandle> {
         let parent_node = self.lookup_node_mut(node_handle.parent_handle());
         let index = node_handle.index_in_parent();
         match parent_node {

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -102,7 +102,7 @@ impl DomLocation {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MultipleNodesRange {
     pub locations: Vec<DomLocation>,
 }


### PR DESCRIPTION
Modified `NodeJoiner` so it can also join nodes after formatting is applied to several nodes.