### PR TITLE
Add debug tree representation

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -135,6 +135,10 @@ impl ComposerModel {
         ))
     }
 
+    pub fn to_tree(self: &Arc<Self>) -> String {
+        self.inner.lock().unwrap().to_tree().to_string()
+    }
+
     pub fn dump_state(self: &Arc<Self>) -> ComposerState {
         self.inner
             .lock()

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -30,6 +30,7 @@ interface ComposerModel {
     ComposerUpdate undo();
     ComposerUpdate redo();
     ComposerUpdate set_link(string new_text);
+    string to_tree();
     ComposerState dump_state();
     ComposerUpdate action_response(string action_id, ActionResponse response);
 };

--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -15,7 +15,9 @@
 use crate::dom::nodes::{DomNode, TextNode};
 use crate::dom::parser::parse;
 use crate::dom::UnicodeString;
-use crate::dom::{DomHandle, MultipleNodesRange, Range, SameNodeRange, ToHtml};
+use crate::dom::{
+    DomHandle, MultipleNodesRange, Range, SameNodeRange, ToHtml, ToTree,
+};
 use crate::{
     ActionResponse, ComposerState, ComposerUpdate, Location, NodeJoiner,
 };
@@ -408,6 +410,10 @@ where
         } else {
             panic!("Trying to bold a non-text node")
         }
+    }
+
+    pub fn to_tree(&self) -> S {
+        self.state.dom.to_tree()
     }
 }
 

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -23,6 +23,7 @@ pub mod parser;
 pub mod range;
 pub mod to_html;
 pub mod to_raw_text;
+pub mod to_tree;
 pub mod unicode_string;
 
 pub use dom_creation_error::DomCreationError;
@@ -37,4 +38,5 @@ pub use range::Range;
 pub use range::SameNodeRange;
 pub use to_html::ToHtml;
 pub use to_raw_text::ToRawText;
+pub use to_tree::ToTree;
 pub use unicode_string::UnicodeString;

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
 use crate::dom::{
-    find_range, to_raw_text::ToRawText, DomHandle, Range, UnicodeString,
+    find_range, to_raw_text::ToRawText, DomHandle, Range, ToTree, UnicodeString,
 };
 use crate::ToHtml;
 
@@ -219,6 +219,15 @@ where
 {
     fn to_raw_text(&self) -> S {
         self.document.to_raw_text()
+    }
+}
+
+impl<S> ToTree<S> for Dom<S>
+where
+    S: UnicodeString,
+{
+    fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
+        self.document.to_tree_display(continuous_positions)
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -17,6 +17,7 @@ use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::nodes::dom_node::DomNode;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
+use crate::dom::to_tree::ToTree;
 use crate::dom::{HtmlChar, UnicodeString};
 use crate::InlineFormatType;
 
@@ -335,6 +336,28 @@ where
             text.push_string(&child.to_raw_text());
         }
         return text;
+    }
+}
+
+impl<S> ToTree<S> for ContainerNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
+        let mut tree_part = self.tree_line(
+            self.name.clone(),
+            self.handle.raw().len(),
+            continuous_positions.clone(),
+        );
+
+        for (i, child) in self.children.iter().enumerate() {
+            let mut new_positions = continuous_positions.clone();
+            if i < self.children.len() - 1 {
+                new_positions.push(self.handle.raw().len());
+            }
+            tree_part.push_string(&child.to_tree_display(new_positions));
+        }
+        return tree_part;
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -18,6 +18,7 @@ use crate::dom::nodes::container_node::ContainerNode;
 use crate::dom::nodes::text_node::TextNode;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
+use crate::dom::to_tree::ToTree;
 use crate::dom::UnicodeString;
 use crate::InlineFormatType;
 
@@ -130,6 +131,18 @@ where
         match self {
             DomNode::Container(n) => n.to_raw_text(),
             DomNode::Text(n) => n.to_raw_text(),
+        }
+    }
+}
+
+impl<S> ToTree<S> for DomNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
+        match self {
+            DomNode::Container(n) => n.to_tree_display(continuous_positions),
+            DomNode::Text(n) => n.to_tree_display(continuous_positions),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -16,6 +16,7 @@ use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
+use crate::dom::to_tree::ToTree;
 use crate::dom::UnicodeString;
 
 use html_escape;
@@ -79,5 +80,21 @@ where
 {
     fn to_raw_text(&self) -> S {
         self.data.clone()
+    }
+}
+
+impl<S> ToTree<S> for TextNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
+        let mut description = S::from_str("\"");
+        description.push_string(&self.data.clone());
+        description.push_string(&S::from_str("\""));
+        return self.tree_line(
+            description,
+            self.handle.raw().len(),
+            continuous_positions,
+        );
     }
 }

--- a/crates/wysiwyg/src/dom/to_tree.rs
+++ b/crates/wysiwyg/src/dom/to_tree.rs
@@ -1,0 +1,91 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use super::UnicodeString;
+
+pub trait ToTree<S>
+where
+    S: UnicodeString,
+{
+    /// Output tree representation from current item.
+    fn to_tree(&self) -> S {
+        self.to_tree_display(vec![])
+    }
+
+    /// Output tree representation from current item with
+    /// given vector of ancestors that have extra children.
+    fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S;
+
+    /// Output content of a tree line with given description
+    /// with current depth in the tree as well as positions
+    /// of ancestor that have extra children.
+    fn tree_line(
+        &self,
+        description: S,
+        depth: usize,
+        continuous_positions: Vec<usize>,
+    ) -> S {
+        let mut tree_part = S::from_str("");
+        for i in 0..depth {
+            if i == depth - 1 {
+                if continuous_positions.contains(&i) {
+                    tree_part
+                        .push_string(&TreeSymbols::vertical_right_and_gt());
+                } else {
+                    tree_part.push_string(&TreeSymbols::up_right_and_gt());
+                }
+            } else {
+                if continuous_positions.contains(&i) {
+                    tree_part
+                        .push_string(&TreeSymbols::vertical_and_whitespace());
+                } else {
+                    tree_part.push_string(&TreeSymbols::double_whitespace());
+                }
+            }
+        }
+        tree_part.push_string(&description);
+        tree_part.push_string(&S::from_str("\n"));
+        return tree_part;
+    }
+}
+
+struct TreeSymbols<S>
+where
+    S: UnicodeString,
+{
+    phantom_data: PhantomData<S>,
+}
+
+impl<S> TreeSymbols<S>
+where
+    S: UnicodeString,
+{
+    fn double_whitespace() -> S {
+        S::from_str("\u{0020}\u{0020}")
+    }
+
+    fn up_right_and_gt() -> S {
+        S::from_str("\u{2514}\u{003E}")
+    }
+
+    fn vertical_right_and_gt() -> S {
+        S::from_str("\u{251C}\u{003E}")
+    }
+
+    fn vertical_and_whitespace() -> S {
+        S::from_str("\u{2502}\u{0020}")
+    }
+}

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::composer_state::ComposerState;
 pub use crate::composer_update::ComposerUpdate;
 pub use crate::dom::ToHtml;
 pub use crate::dom::ToRawText;
+pub use crate::dom::ToTree;
 pub use crate::dom::UnicodeString;
 pub use crate::format_type::InlineFormatType;
 pub use crate::location::Location;

--- a/crates/wysiwyg/src/tests/test_to_tree.rs
+++ b/crates/wysiwyg/src/tests/test_to_tree.rs
@@ -12,15 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod test_characters;
-pub mod test_deleting;
-pub mod test_formatting;
-pub mod test_links;
-pub mod test_lists;
-pub mod test_selection;
-pub mod test_to_raw_text;
-pub mod test_to_tree;
-pub mod test_undo_redo;
-pub mod testutils_composer_model;
-pub mod testutils_conversion;
-pub mod testutils_dom;
+#![cfg(test)]
+
+use crate::tests::testutils_composer_model::cm;
+use crate::ToTree;
+
+#[test]
+fn computing_tree() {
+    let model = cm("<b>abc<i>def</i></b>|");
+    assert_eq!(
+        model.state.dom.to_tree(),
+        "
+├>b
+│ ├>\"abc\"
+│ └>i
+│   └>\"def\"
+└>\"\"
+",
+    );
+
+    let model =
+        cm("<ul><li>ab</li><li><b>cd</b></li><li><i><b>ef|</b></i></li></ul>");
+    assert_eq!(
+        model.state.dom.to_tree(),
+        "
+└>ul
+  ├>li
+  │ └>\"ab\"
+  ├>li
+  │ └>b
+  │   └>\"cd\"
+  └>li
+    └>i
+      └>b
+        └>\"ef\"
+",
+    );
+}

--- a/platforms/ios/example/Wysiwyg/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/ContentView.swift
@@ -23,6 +23,7 @@ import WysiwygShared
 struct ContentView: View {
     /// A composer content "saved" and displayed upon hitting the send button.
     @State private var sentMessage: WysiwygComposerContent?
+    @State private var tree: String?
     /// View model for the composer.
     @StateObject private var viewModel = WysiwygComposerViewModel()
 
@@ -39,6 +40,14 @@ struct ContentView: View {
         }
         .disabled(viewModel.isContentEmpty)
         .accessibilityIdentifier(.sendButton)
+        Button("Show tree") {
+            tree = viewModel.treeRepresentation()
+        }
+        if let tree = tree {
+            Text(tree)
+                .font(.system(.body, design: .monospaced))
+                .multilineTextAlignment(.leading)
+        }
         if let sentMessage = sentMessage {
             VStack {
                 HStack {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -47,6 +47,10 @@ public class WysiwygComposerViewModel: ObservableObject {
         self.model = newComposerModel()
         self.content = WysiwygComposerContent()
     }
+
+    public func treeRepresentation() -> String {
+        return self.model.toTree()
+    }
 }
 
 // MARK: - Internal

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -87,6 +87,19 @@ final class WysiwygComposerTests: XCTestCase {
                 XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
             }
         }
+
+        let tree = composer.toTree()
+        XCTAssertEqual(
+            tree,
+            """
+
+            ├>\"This is \"
+            ├>strong
+            │ └>\"bold\"
+            └>\" text\"
+
+            """
+        )
     }
 
     func testLists() {


### PR DESCRIPTION
Adds a Rust-based solution that allows to display the current tree

<img src="https://user-images.githubusercontent.com/80891108/187712680-2571e3b4-bc4c-49ac-85a3-a9edc2e287cd.png" width="300" />