### PR TITLE
Handle backspace in lists

### DIFF
--- a/crates/wysiwyg/src/composer_list_handler.rs
+++ b/crates/wysiwyg/src/composer_list_handler.rs
@@ -30,6 +30,36 @@ where
         self.create_list(false)
     }
 
+    pub(crate) fn do_backspace_in_list(
+        &mut self,
+        parent_handle: DomHandle,
+        location: usize,
+        range: SameNodeRange,
+    ) -> ComposerUpdate<S> {
+        // do_backspace_in_list should only be called on a single location
+        // as selection can be handled in standard do_backspace.
+        assert_eq!(range.start_offset, range.end_offset);
+        let parent_node = self.state.dom.lookup_node(parent_handle.clone());
+        let list_node_handle = parent_node.handle().parent_handle();
+        if let DomNode::Container(parent) = parent_node {
+            if parent.is_empty_list_item() {
+                // Store current Dom
+                self.push_state_to_history();
+                self.remove_list_item(
+                    list_node_handle,
+                    location,
+                    parent_handle.index_in_parent(),
+                    false,
+                );
+                self.create_update_replace_all()
+            } else {
+                self.do_backspace()
+            }
+        } else {
+            panic!("No list item found")
+        }
+    }
+
     pub(crate) fn do_enter_in_list(
         &mut self,
         parent_handle: DomHandle,

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -46,11 +46,42 @@ fn removing_list_item() {
     let mut model = cm("<ol><li>abcd</li><li>\u{200b}|</li></ol>");
     model.enter();
     assert_eq!(tx(&model), "<ol><li>abcd</li></ol>\u{200b}|");
+
+    let mut model = cm("<ol><li>abcd</li><li>\u{200b}|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "<ol><li>abcd|</li></ol>");
+
+    let mut model = cm("<ol><li>|</li></ol>");
+    model.enter();
+    assert_eq!(tx(&model), "|");
+
+    let mut model = cm("<ol><li>|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "|");
+}
+
+#[test]
+fn backspacing_in_list() {
+    let mut model = cm("<ol><li>abcd</li><li>\u{200b}ef{gh}|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "<ol><li>abcd</li><li>\u{200b}ef|</li></ol>");
+
+    let mut model = cm("<ol><li>ab{cd</li><li>\u{200b}efgh}|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "<ol><li>ab|</li></ol>");
+
+    let mut model = cm("<ol><li>{abcd</li><li>\u{200b}}|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "<ol><li>|</li></ol>");
 }
 
 #[test]
 fn entering_with_entire_selection() {
     let mut model = cm("<ol><li>{abcd}|</li></ol>");
+    model.enter();
+    assert_eq!(tx(&model), "|");
+
+    let mut model = cm("<ol><li>{abcd</li><li>\u{200b}}|</li></ol>");
     model.enter();
     assert_eq!(tx(&model), "|");
 }


### PR DESCRIPTION
Add backspace handling code for lists and expand Rust test suite for list cases