### PR TITLE
[iOS] Fix numbered list regexp & some lint issues

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -45,22 +45,24 @@ struct ContentView: View {
         Button("Show tree") {
             tree = viewModel.treeRepresentation()
         }
-        if let tree = tree {
-            Text(tree)
-                .font(.system(.body, design: .monospaced))
-                .multilineTextAlignment(.leading)
-        }
-        if let sentMessage = sentMessage {
-            VStack {
-                HStack {
-                    Text("Content:")
-                    Text(sentMessage.plainText)
-                        .accessibilityIdentifier(.contentText)
-                }
-                HStack {
-                    Text("HTML:")
-                    Text(sentMessage.html)
-                        .accessibilityIdentifier(.htmlContentText)
+        ScrollView {
+            if let tree = tree {
+                Text(tree)
+                    .font(.system(.body, design: .monospaced))
+                    .multilineTextAlignment(.leading)
+            }
+            if let sentMessage = sentMessage {
+                VStack {
+                    HStack {
+                        Text("Content:")
+                        Text(sentMessage.plainText)
+                            .accessibilityIdentifier(.contentText)
+                    }
+                    HStack {
+                        Text("HTML:")
+                        Text(sentMessage.html)
+                            .accessibilityIdentifier(.htmlContentText)
+                    }
                 }
             }
         }

--- a/platforms/ios/lib/WysiwygComposer/.swiftlint.yml
+++ b/platforms/ios/lib/WysiwygComposer/.swiftlint.yml
@@ -1,0 +1,14 @@
+# rule identifiers to exclude from running
+disabled_rules:
+  - todo
+
+# paths to ignore during linting. Takes precedence over `included`.
+excluded:
+  - Sources/WysiwygComposer/WysiwygComposer.swift
+
+line_length:
+  warning: 140
+  error: 200
+
+trailing_comma:
+    mandatory_comma: true

--- a/platforms/ios/lib/WysiwygComposer/Package.swift
+++ b/platforms/ios/lib/WysiwygComposer/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "WysiwygComposer",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v14),
     ],
     products: [
         .library(
@@ -22,7 +22,7 @@ let package = Package(
         .target(
             name: "WysiwygComposer",
             dependencies: [
-                .target(name: "WysiwygComposerFFI")
+                .target(name: "WysiwygComposerFFI"),
             ]
         ),
         .testTarget(

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -21,9 +21,9 @@ import OSLog
 struct WysiwygComposerView: UIViewRepresentable {
     // MARK: - Internal
     var content: WysiwygComposerContent
-    var replaceText: (NSAttributedString, NSRange, String) -> ()
-    var select: (NSAttributedString, NSRange) -> ()
-    var didUpdateText: (UITextView) -> ()
+    var replaceText: (NSAttributedString, NSRange, String) -> Void
+    var select: (NSAttributedString, NSRange) -> Void
+    var didUpdateText: (UITextView) -> Void
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
@@ -51,13 +51,13 @@ struct WysiwygComposerView: UIViewRepresentable {
 
     /// Coordinates UIKit communication.
     class Coordinator: NSObject, UITextViewDelegate, NSTextStorageDelegate {
-        var replaceText: (NSAttributedString, NSRange, String) -> ()
-        var select: (NSAttributedString, NSRange) -> ()
-        var didUpdateText: (UITextView) -> ()
+        var replaceText: (NSAttributedString, NSRange, String) -> Void
+        var select: (NSAttributedString, NSRange) -> Void
+        var didUpdateText: (UITextView) -> Void
 
-        init(_ replaceText: @escaping (NSAttributedString, NSRange, String) -> (),
-             _ select: @escaping (NSAttributedString, NSRange) -> (),
-             _ didUpdateText: @escaping (UITextView) -> ()) {
+        init(_ replaceText: @escaping (NSAttributedString, NSRange, String) -> Void,
+             _ select: @escaping (NSAttributedString, NSRange) -> Void,
+             _ didUpdateText: @escaping (UITextView) -> Void) {
             self.replaceText = replaceText
             self.select = select
             self.didUpdateText = didUpdateText

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygHostingView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygHostingView.swift
@@ -80,7 +80,7 @@ public final class WysiwygHostingView: UIView {
                 .removeDuplicates()
                 .sink(receiveValue: { [unowned self] idealHeight in
                     self.delegate?.idealHeightDidChange(idealHeight)
-                })
+                }),
         ]
 
         // Attach the view to a hosting controller and display it's UIView container.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -56,6 +56,4 @@ extension NSAttributedString {
         let font = self.attribute(.font, at: index, effectiveRange: nil) as? UIFont
         return font?.fontDescriptor.symbolicTraits ?? []
     }
-
-
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Range.swift
@@ -66,6 +66,7 @@ extension NSAttributedString {
                                     shouldIgnoreTrailingNewline: Bool = true) -> [NSRange] {
         let pattern = shouldIgnoreTrailingNewline ? "[\\n]?\\t•\\t" : "\\t•\\t"
         let actualRange = range ?? .init(location: 0, length: length)
+        // swiftlint:disable:next force_try
         let regex = try! NSRegularExpression(pattern: pattern)
         return regex
             .matches(in: string, range: actualRange)
@@ -84,6 +85,7 @@ extension NSAttributedString {
                                     shouldIgnoreTrailingNewline: Bool = true) -> [NSRange] {
         let pattern = shouldIgnoreTrailingNewline ? "[\\n]?\\t\\d+\\.\\t" : "\\t\\d\\.\\t"
         let actualRange = range ?? .init(location: 0, length: length)
+        // swiftlint:disable:next force_try
         let regex = try! NSRegularExpression(pattern: pattern)
         return regex
             .matches(in: string, range: actualRange)
@@ -138,7 +140,7 @@ extension NSAttributedString {
                 // Should only count the listPrefix in if we are
                 // not on an inserted newline from end of <li>
                 if !(attributedSubstring(from: .init(location: actualIndex, length: 1))
-                    .string == "\n"){
+                    .string == "\n") {
                     actualIndex += listPrefix.length
                 }
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Range.swift
@@ -82,7 +82,7 @@ extension NSAttributedString {
     /// - Returns: an array of matching ranges
     func numberedListPrefixesRanges(in range: NSRange? = nil,
                                     shouldIgnoreTrailingNewline: Bool = true) -> [NSRange] {
-        let pattern = shouldIgnoreTrailingNewline ? "[\\n]?\\t\\d\\.\\t" : "\\t\\d\\.\\t"
+        let pattern = shouldIgnoreTrailingNewline ? "[\\n]?\\t\\d+\\.\\t" : "\\t\\d\\.\\t"
         let actualRange = range ?? .init(location: 0, length: length)
         let regex = try! NSRegularExpression(pattern: pattern)
         return regex

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringAttributesTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringAttributesTests.swift
@@ -19,13 +19,15 @@ import XCTest
 
 final class NSAttributedStringTests: XCTestCase {
     func testEnumerateTypedAttribute() {
-        let attributed = NSMutableAttributedString(string: "Test", attributes: [.font : UIFont.boldSystemFont(ofSize: 15)])
+        let attributed = NSMutableAttributedString(string: "Test",
+                                                   attributes: [.font: UIFont.boldSystemFont(ofSize: 15)])
         attributed.enumerateTypedAttribute(.font) { (font: UIFont, range: NSRange, _) in
             XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
             XCTAssertTrue(range == .init(location: 0, length: attributed.length))
         }
         attributed.addAttribute(.font, value: "bad type", range: .init(location: 2, length: 2))
         attributed.enumerateTypedAttribute(.font) { (font: UIFont, range: NSRange, _) in
+            XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
             XCTAssertTrue(range == .init(location: 0, length: 2))
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
@@ -27,7 +27,8 @@ final class NSAttributedStringRangeTests: XCTestCase {
         // Ranges that are not part of the raw HTML text (excluding tags) are detected
         XCTAssertEqual(attributed.listPrefixesRanges(),
                        [NSRange(location: 0, length: 4),
-                        NSRange(location: 10, length: 5)])
+                        NSRange(location: 10, length: 5),
+                       ])
         // Converting back and forth from HTML to attributed postions
         XCTAssertEqual(try attributed.attributedPosition(at: 0), 4)
         XCTAssertEqual(try attributed.attributedPosition(at: 7), 16)
@@ -69,7 +70,8 @@ final class NSAttributedStringRangeTests: XCTestCase {
                        "\t•\tItem 1\n\t•\tItem 2\nSome Text")
         XCTAssertEqual(attributed.listPrefixesRanges(),
                        [NSRange(location: 0, length: 3),
-                        NSRange(location: 9, length: 4)])
+                        NSRange(location: 9, length: 4),
+                       ])
         XCTAssertEqual(try attributed.attributedPosition(at: 0), 3)
         XCTAssertEqual(try attributed.attributedPosition(at: 7), 14)
         XCTAssertEqual(try attributed.htmlPosition(at: 14), 7)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
@@ -95,6 +95,17 @@ final class NSAttributedStringRangeTests: XCTestCase {
                        NSRange(location: 0, length: 12))
     }
 
+    func testMultipleDigitsNumberedLists() throws {
+        var html = "<ol>"
+        for _ in 1...10 {
+            html.append(contentsOf: "<li>abcd</li>")
+        }
+        html.append(contentsOf: "</ol>")
+        let attributed = try NSAttributedString(html: html)
+        XCTAssertEqual(attributed.listPrefixesRanges().count,
+                       10)
+    }
+
     func testOutOfBoundsIndexes() throws {
         let html = "<ol><li>Item 1</li><li>Item 2</li></ol>Some Text"
         let attributed = try NSAttributedString(html: html)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
@@ -99,13 +99,13 @@ final class NSAttributedStringRangeTests: XCTestCase {
 
     func testMultipleDigitsNumberedLists() throws {
         var html = "<ol>"
-        for _ in 1...10 {
+        for _ in 1...100 {
             html.append(contentsOf: "<li>abcd</li>")
         }
         html.append(contentsOf: "</ol>")
         let attributed = try NSAttributedString(html: html)
         XCTAssertEqual(attributed.listPrefixesRanges().count,
-                       10)
+                       100)
     }
 
     func testOutOfBoundsIndexes() throws {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -28,7 +28,7 @@ final class WysiwygComposerTests: XCTestCase {
         let update = composer.replaceText(newText: TestConstants.testStringWithEmojis)
         switch update.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):
@@ -51,7 +51,7 @@ final class WysiwygComposerTests: XCTestCase {
         let update = composer.backspace()
         switch update.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):
@@ -63,14 +63,14 @@ final class WysiwygComposerTests: XCTestCase {
         }
     }
 
-    func testFormatBold() {
+    func testFormatBold() throws {
         let composer = newComposerModel()
         _ = composer.replaceText(newText: "This is bold text")
         composer.select(startUtf16Codeunit: 8, endUtf16Codeunit: 12)
         let update = composer.format(type: .bold)
         switch update.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):
@@ -81,7 +81,7 @@ final class WysiwygComposerTests: XCTestCase {
             XCTAssertEqual(start, 8)
             XCTAssertEqual(end, 12)
             // Constructed attributed string sets bold on the selected range.
-            let attributed = try! NSAttributedString(html: html)
+            let attributed = try NSAttributedString(html: html)
             attributed.enumerateTypedAttribute(.font, in: .init(location: 8, length: 4)) { (font: UIFont, range, _) in
                 XCTAssertEqual(range, .init(location: 8, length: 4))
                 XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
@@ -102,6 +102,7 @@ final class WysiwygComposerTests: XCTestCase {
         )
     }
 
+    // swiftlint:disable:next function_body_length
     func testLists() {
         let composer = newComposerModel()
         _ = composer.createOrderedList()
@@ -112,7 +113,7 @@ final class WysiwygComposerTests: XCTestCase {
         let update = composer.enter()
         switch update.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):
@@ -130,7 +131,7 @@ final class WysiwygComposerTests: XCTestCase {
         let update2 = composer.enter()
         switch update2.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):
@@ -147,7 +148,7 @@ final class WysiwygComposerTests: XCTestCase {
         let update3 = composer.replaceText(newText: "Some text")
         switch update3.textUpdate() {
         case .keep:
-            XCTFail()
+            XCTFail("Expected replace all HTML update")
         case .replaceAll(replacementHtml: let codeUnits,
                          startUtf16Codeunit: let start,
                          endUtf16Codeunit: let end):


### PR DESCRIPTION
Fixes an issue with numbered list with more than 9 items. 
Also fixes a few lint issues in the iOS library code.