### PR TITLE
Android: add lists support

### DIFF
--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -178,3 +178,11 @@ fn deleting_in_nested_structure_and_format_nodes_works() {
     model.delete();
     assert_eq!(tx(&model), "<ul><li>A</li><li><b>B|C</b></li></ul>");
 }
+
+#[test]
+#[ignore] // TODO: fix this test once this deletion works
+fn deleting_empty_list_item() {
+    let mut model = cm("<ul><li>A{</li><li>\u{200B}}|</li></ul>");
+    model.backspace();
+    assert_eq!(tx(&model), "<ul><li>A|</li></ul>");
+}

--- a/platforms/android/.gitignore
+++ b/platforms/android/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 /local.properties
 /.idea/caches
+/.idea/deploymentTargetDropDown.xml
 /.idea/libraries
 /.idea/misc.xml
 /.idea/modules.xml

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
+    // XML Parsing
+    implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2'
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'

--- a/platforms/android/library/src/androidTest/res/layout/activity_test.xml
+++ b/platforms/android/library/src/androidTest/res/layout/activity_test.xml
@@ -7,7 +7,6 @@
     tools:context="io.element.android.wysiwyg.poc.MainActivity">
 
     <io.element.android.wysiwyg.RichTextEditor
-        android:id="@+id/richTextEditor"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/RichTextEditor.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/RichTextEditor.kt
@@ -50,6 +50,12 @@ class RichTextEditor : TextInputLayout {
             redoButton.setOnClickListener {
                 editText.redo()
             }
+            orderedListButton.setOnClickListener {
+                editText.toggleList(true)
+            }
+            unorderedListButton.setOnClickListener {
+                editText.toggleList(false)
+            }
         }
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/ComposerExtensions.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/ComposerExtensions.kt
@@ -9,5 +9,7 @@ val LOG_ENABLED = BuildConfig.DEBUG
 
 fun ComposerState.dump() = "'${html.string()}' | Start: $start | End: $end"
 fun ComposerModel.log() = if (LOG_ENABLED)
-    Log.d("COMPOSER_PROCESSOR", dumpState().dump())
+    Log.d("COMPOSER_PROCESSOR", dumpState().dump()
+            // To visualize zero-width spaces easily
+        .replace("\u200b", "*"))
 else 0

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/HtmlToSpansParser.kt
@@ -1,0 +1,198 @@
+package io.element.android.wysiwyg.spans
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.NoCopySpan
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.BulletSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import androidx.core.text.getSpans
+import io.element.android.wysiwyg.InlineFormat
+import org.ccil.cowan.tagsoup.Parser
+import org.xml.sax.Attributes
+import org.xml.sax.ContentHandler
+import org.xml.sax.InputSource
+import org.xml.sax.Locator
+import java.io.StringReader
+import kotlin.math.roundToInt
+
+class HtmlToSpansParser(
+    private val context: Context,
+    private val html: String,
+): ContentHandler {
+
+    data class Hyperlink(val link: String)
+    object OrderedListBlock
+    object UnorderedListBlock
+    class ZeroWidthLineBreak: NoCopySpan
+    data class ListItem(val ordered: Boolean, val order: Int? = null)
+
+    private val parser = Parser().also { it.contentHandler = this }
+    private val text = SpannableStringBuilder()
+
+    fun convert(): Spanned {
+        parser.parse(InputSource(StringReader(html)))
+        return text
+    }
+
+    override fun setDocumentLocator(locator: Locator?) {}
+
+    override fun startDocument() {}
+
+    override fun endDocument() {}
+
+    override fun startPrefixMapping(prefix: String?, uri: String?) {}
+
+    override fun endPrefixMapping(prefix: String?) {}
+
+    override fun startElement(uri: String?, localName: String, qName: String?, atts: Attributes?) {
+        handleStartTag(localName, atts)
+    }
+
+    override fun endElement(uri: String?, localName: String, qName: String?) {
+        handleEndTag(localName)
+    }
+
+    override fun characters(ch: CharArray, start: Int, length: Int) {
+        for (i in start until start+length) {
+            val char = ch[i]
+            text.append(char)
+        }
+    }
+
+    override fun ignorableWhitespace(ch: CharArray, start: Int, length: Int) {}
+
+    override fun processingInstruction(target: String?, data: String?) {}
+
+    override fun skippedEntity(name: String?) {}
+
+    private fun handleStartTag(name: String, attrs: Attributes?) {
+        when (name) {
+            "b", "strong" -> handleFormatStartTag(InlineFormat.Bold)
+            "i", "em" -> handleFormatStartTag(InlineFormat.Italic)
+            "u" -> handleFormatStartTag(InlineFormat.Underline)
+            "del" -> handleFormatStartTag(InlineFormat.StrikeThrough)
+            "code" -> handleFormatStartTag(InlineFormat.InlineCode)
+            "a" -> {
+                val url = attrs?.getValue("href") ?: return
+                handleHyperlinkStart(url)
+            }
+            "ul", "ol" -> {
+                val mark = if (name == "ol") OrderedListBlock else UnorderedListBlock
+                text.setSpan(mark, text.length, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+            }
+            "li" -> {
+                val lastListBlock = getLast<OrderedListBlock>() ?: getLast<UnorderedListBlock>() ?: return
+                val start = text.getSpanStart(lastListBlock)
+                val newItem = when (lastListBlock) {
+                    is OrderedListBlock -> {
+                        val lastListItem = getLast<OrderedListSpan>(from = start)
+                        val order = (lastListItem?.order ?: 0) + 1
+                        ListItem(true, order)
+                    }
+                    is UnorderedListBlock -> ListItem(false)
+                    else -> return
+                }
+                text.setSpan(newItem, text.length, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+            }
+        }
+    }
+
+    private fun handleEndTag(name: String) {
+        when (name) {
+            "br" -> text.append("\n")
+            "b", "strong" -> handleFormatEndTag(InlineFormat.Bold)
+            "i", "em" -> handleFormatEndTag(InlineFormat.Italic)
+            "u" -> handleFormatEndTag(InlineFormat.Underline)
+            "del" -> handleFormatEndTag(InlineFormat.StrikeThrough)
+            "code" -> handleFormatEndTag(InlineFormat.InlineCode)
+            "a" -> handleHyperlinkEnd()
+            "ul", "ol" -> {
+                val mark = if (name == "ol") OrderedListBlock else UnorderedListBlock
+                val last = getLast(mark::class.java) ?: return
+                text.removeSpan(last)
+            }
+            "li" -> {
+                val last = getLast<ListItem>() ?: return
+                val start = text.getSpanStart(last)
+                var lineBreakAdded = false
+                // We only add line breaks *after* a previous <li> element if there is not already a line break
+                if (start == 0) {
+                    val zeroWidthSpan = SpannableString("\u200b").apply {
+                        setSpan(ZeroWidthLineBreak(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    }
+                    text.append(zeroWidthSpan)
+                } else if (start > 0 && start <= text.length && text[start-1] != '\n') {
+                    // We add a line break and an zero width character to actually display the list item
+                    val zeroWidthLineBreakSpan = SpannableString("\n").apply {
+                        setSpan(ZeroWidthLineBreak(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    }
+                    text.insert(start, zeroWidthLineBreakSpan)
+                    lineBreakAdded = true
+                }
+                val newStart = if (lineBreakAdded) start+1 else start
+                // TODO: provide gap width, typeface and textSize somehow
+                val gapWidth = (10f * context.resources.displayMetrics.density).roundToInt()
+                val span = if (last.ordered) {
+                    val typeface = Typeface.defaultFromStyle(Typeface.NORMAL)
+                    val textSize = 16f * context.resources.displayMetrics.scaledDensity
+                    OrderedListSpan(typeface, textSize, last.order ?: 1, gapWidth)
+                } else {
+                    BulletSpan(gapWidth)
+                }
+                text.setSpan(span, newStart, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                text.removeSpan(last)
+            }
+        }
+    }
+
+    private fun handleFormatStartTag(format: InlineFormat) {
+        text.setSpan(format, text.length, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+    }
+
+    private fun handleFormatEndTag(format: InlineFormat) {
+        val span = when (format) {
+            InlineFormat.Bold -> StyleSpan(Typeface.BOLD)
+            InlineFormat.Italic -> StyleSpan(Typeface.ITALIC)
+            InlineFormat.Underline -> UnderlineSpan()
+            InlineFormat.StrikeThrough -> StrikethroughSpan()
+            InlineFormat.InlineCode -> InlineCodeSpan(context)
+        }
+        setSpanFromMark(format, span)
+    }
+
+    private fun handleHyperlinkStart(url: String) {
+        val hyperlink = Hyperlink(url)
+        text.setSpan(hyperlink, text.length, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+    }
+    private fun handleHyperlinkEnd() {
+        val last = getLast<Hyperlink>() ?: return
+        // TODO: use custom link span maybe
+        val span = UnderlineSpan()
+        setSpanFromMark(last, span)
+    }
+
+    private fun setSpanFromMark(mark: Any, vararg spans: Any) {
+        val lastTag = getLast(mark::class.java) ?: return
+        val startIndex = text.getSpanStart(lastTag)
+        for (span in spans) {
+            text.setSpan(span, startIndex, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+        text.removeSpan(lastTag)
+    }
+
+    private inline fun <reified T: Any> getLast(from: Int = 0, to: Int = text.length): T? {
+        val spans = text.getSpans<T>(from, to)
+        return spans.lastOrNull()
+    }
+
+    private fun <T: Any> getLast(kind: Class<T>, from: Int = 0, to: Int = text.length): T? {
+        val spans = text.getSpans(from, to, kind)
+        return spans.lastOrNull()
+    }
+
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/OrderedListSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/OrderedListSpan.kt
@@ -1,0 +1,51 @@
+package io.element.android.wysiwyg.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
+import android.text.Layout
+import android.text.style.LeadingMarginSpan
+
+class OrderedListSpan(
+    typeface: Typeface,
+    textSize: Float,
+    val order: Int,
+    private val gapWidth: Int,
+) : LeadingMarginSpan {
+
+    private val prefix = "$order."
+    private val prefixToMeasure = "99."
+
+    private val typefacePaint = Paint().apply {
+        this.textSize = textSize
+        this.typeface = typeface
+        style = Paint.Style.STROKE
+    }
+
+    override fun getLeadingMargin(first: Boolean): Int {
+        val bounds = Rect()
+        typefacePaint.getTextBounds(prefixToMeasure, 0, prefixToMeasure.length, bounds)
+        return bounds.width() + gapWidth
+    }
+
+    override fun drawLeadingMargin(
+        c: Canvas,
+        p: Paint,
+        x: Int,
+        dir: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        first: Boolean,
+        layout: Layout?
+    ) {
+        val bounds = Rect()
+        p.getTextBounds(prefix, 0, prefix.length, bounds)
+        val xEnd = x + getLeadingMargin(true) - gapWidth - bounds.width()
+        c.drawText(prefix, 0, prefix.length, xEnd.toFloat(), baseline.toFloat(), p)
+    }
+}

--- a/platforms/android/library/src/main/res/drawable/ic_ordered_list.xml
+++ b/platforms/android/library/src/main/res/drawable/ic_ordered_list.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M2,17h2v0.5L3,17.5v1h1v0.5L2,19v1h3v-4L2,16v1zM3,8h1L4,4L2,4v1h1v3zM2,11h1.8L2,13.1v0.9h3v-1L3.2,13L5,10.9L5,10L2,10v1zM7,5v2h14L21,5L7,5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2z"/>
+</vector>

--- a/platforms/android/library/src/main/res/drawable/ic_unordered_list.xml
+++ b/platforms/android/library/src/main/res/drawable/ic_unordered_list.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z"/>
+</vector>

--- a/platforms/android/library/src/main/res/layout/view_rich_text_editor.xml
+++ b/platforms/android/library/src/main/res/layout/view_rich_text_editor.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="48dp"
-        android:inputType="text"
+        android:inputType="textMultiLine"
         android:gravity="top"
         android:singleLine="false" />
 
@@ -75,6 +75,20 @@
                     android:layout_marginEnd="4dp"
                     android:src="@drawable/ic_link"
                     android:contentDescription="Hyperlink" />
+
+                <ImageButton android:id="@+id/orderedListButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    android:src="@drawable/ic_ordered_list"
+                    android:contentDescription="Ordered list" />
+
+                <ImageButton android:id="@+id/unorderedListButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    android:src="@drawable/ic_unordered_list"
+                    android:contentDescription="Unordered list" />
 
 
             </LinearLayout>


### PR DESCRIPTION
* Adds lists for Android (BulletSpan and OrderedListSpan).
* Creates `HtmlToSpansParser` based on the default `Html.fromHtml` implementation.
* Adds indexes mapping between the composer and the actual UI element on Android, as they diverged when we included line breaks and zero-width characters.