### PR TITLE
Skip the selection behavior when the selection is not in the composer

### DIFF
--- a/platforms/web/example/wysiwyg.js
+++ b/platforms/web/example/wysiwyg.js
@@ -241,6 +241,13 @@ function selection_according_to_actions(actions) {
 }
 
 function selectionchange() {
+    const isInEditor = document.activeElement === editor
+
+    // Skip the selection behavior when the focus is not in the editor
+    if (!isInEditor) {
+        return
+    }
+
     const [start, end] = get_current_selection();
 
     const prev_start = composer_model.selection_start();


### PR DESCRIPTION
In the Web example app, when we select some text outside the composer, the selection is updated to (-1, -1), which is wrong.

We also lose our selection because we grab focus by replacing the editor contents.

When the selection is outside the composer, we should do nothing.