### PR TITLE
Disable removal of empty text nodes for formatting, as it broke some functionality

### DIFF
--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -314,7 +314,7 @@ impl SelectionWritingState {
 
         // If we just passed last or we're at the end, write out }
         let do_last = !self.done_last
-            && (self.last < self.current_pos
+            && (self.last <= self.current_pos
                 || self.current_pos == self.length);
 
         // Remember that we have passed them, so we don't repeat

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -204,9 +204,6 @@ where
                         }
                     }
                     // Clean up by removing any empty text nodes and merging formatting nodes
-                    self.remove_empty_text_nodes(
-                        loc.node_handle.parent_handle(),
-                    );
                     self.merge_formatting_node_with_siblings(
                         loc.node_handle.clone(),
                     );
@@ -261,25 +258,6 @@ where
             Some((orig, new))
         } else {
             None
-        }
-    }
-
-    fn remove_empty_text_nodes(&mut self, handle: DomHandle) {
-        if let DomNode::Container(parent) =
-            self.state.dom.lookup_node_mut(handle.clone())
-        {
-            let mut indexes_to_remove = Vec::new();
-            let children = parent.children();
-            for child in children.iter().rev() {
-                if let DomNode::Text(n) = child {
-                    if n.data().is_empty() {
-                        indexes_to_remove.push(n.handle().index_in_parent());
-                    }
-                }
-            }
-            for i in indexes_to_remove {
-                parent.remove_child(i);
-            }
         }
     }
 

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -41,3 +41,14 @@ fn bolding_ascii_adds_strong_tags() {
     model.format(InlineFormatType::Bold);
     assert_eq!(tx(&model), "aa<strong>|{bb}</strong>cc");
 }
+
+#[test]
+fn format_several_nodes_with_empty_text_nodes() {
+    let mut model = cm("{some}| different nodes");
+    model.format(InlineFormatType::Bold);
+    model.select(Location::from(5), Location::from(14));
+    model.format(InlineFormatType::Italic);
+    model.select(Location::from(2), Location::from(17));
+    model.format(InlineFormatType::StrikeThrough);
+    assert_eq!(tx(&model), "<strong>so<del>{me</del></strong><del> </del><em><del>different</del></em><del> no}|</del>des")
+}


### PR DESCRIPTION
Also, fixed issue in `tx(&model)`.