### PR TITLE
Compute manually the focus offset from the current node

### DIFF
--- a/platforms/web/example/dom.js
+++ b/platforms/web/example/dom.js
@@ -1,0 +1,9 @@
+export function computeSelectionOffset(node, offset = 0) {
+    if (node && node.nodeType === Node.TEXT_NODE) {
+        return offset || node.textContent.length
+    } else if (node.hasChildNodes()) {
+        return Array.from(node.childNodes).map(childNode => computeSelectionOffset(childNode)).reduce((prev, curr) => prev + curr, 0)
+    } else {
+        return 0
+    }
+}

--- a/platforms/web/example/test.js
+++ b/platforms/web/example/test.js
@@ -6,6 +6,8 @@ import {
     selection_according_to_actions
 } from "./wysiwyg.js";
 
+import {computeSelectionOffset} from './dom.js'
+
 const editor = document.getElementById('editor');
 
 run_tests([
@@ -163,6 +165,38 @@ run_tests([
         assert_eq(codeunit_count(editor, thirdTextNode, 0), 9);
         assert_eq(codeunit_count(editor, thirdTextNode, 1), 10);
         assert_eq(codeunit_count(editor, thirdTextNode, 2), 11);
+    }},
+
+    { name: "The offset should contains all the characters when the editor node is selected", test: () => {
+        // When
+        editor.innerHTML = "abc<b>def</b>gh";
+        // Use the editor node and a offset as 1 to simulate the FF behavior 
+        let offset = computeSelectionOffset(editor, 1);
+
+        // Then
+        assert_eq(offset, 8);
+
+         // When
+        editor.innerHTML = "abc<b>def</b>gh<ul><li>alice</li><li>bob</li>";
+        offset = computeSelectionOffset(editor, 1);
+ 
+         // Then
+         assert_eq(offset, 16);
+    }},
+
+    { name: "The offset should contains the selected characters", test: () => {
+        // When
+        editor.innerHTML = "abc<b>def</b>gh<ul><li>alice</li><li>bob</li>";
+        let offset = computeSelectionOffset(editor.childNodes[0], 1);
+
+        // Then
+        assert_eq(offset, 1);
+
+        // When
+        offset = computeSelectionOffset(editor.childNodes[0], 20);
+
+        // Then
+        assert_eq(offset, 20);
     }},
 
     { name: "Selection according to no actions is -1, 1", test: () => {

--- a/platforms/web/example/wysiwyg.js
+++ b/platforms/web/example/wysiwyg.js
@@ -2,6 +2,8 @@
 
 import init, { new_composer_model, new_composer_model_from_html } from './generated/wysiwyg.js';
 
+import {computeSelectionOffset} from './dom.js'
+
 let composer_model;
 let editor;
 let button_bold;
@@ -224,7 +226,7 @@ function get_current_selection() {
     // This should be done when we convert to React
     // Internal task for changing to React: PSU-721
     const start = codeunit_count(editor, s.anchorNode, s.anchorOffset);
-    const end = codeunit_count(editor, s.focusNode, s.focusOffset);
+    const end = codeunit_count(editor, s.focusNode, computeSelectionOffset(s.focusNode, s.focusOffset));
 
     return [start, end];
 }


### PR DESCRIPTION
I add a small recursive function to compute manually the focus offset.

The original offset has an unexpected value in case of a `ctrl+a` in Firefox. 

The focus has  a different behaviour between Chrome and Firefox.
- Chrome => focus  on the text node
- Firefox => focus on the parent div `contentEditable=true`

It clearly needs unitary tests which will arrive _soon_ in the `react` version :)