### PR TITLE
look_up uses copy

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -356,7 +356,7 @@ impl DomHandle {
     /// since we were created, or because you passed in a different model
     /// from the one that created us.)
     pub fn node_type(&self, model: &ComposerModel) -> String {
-        let node = model.inner.state.dom.lookup_node(self.inner.clone());
+        let node = model.inner.state.dom.lookup_node(&self.inner);
         String::from(match node {
             wysiwyg::DomNode::Container(_) => "container",
             wysiwyg::DomNode::Text(_) => "text",
@@ -369,7 +369,7 @@ impl DomHandle {
     /// since we were created, or because you passed in a different model
     /// from the one that created us.)
     pub fn children(&self, model: &ComposerModel) -> DomChildren {
-        let node = model.inner.state.dom.lookup_node(self.inner.clone());
+        let node = model.inner.state.dom.lookup_node(&self.inner);
         match node {
             wysiwyg::DomNode::Container(node) => node
                 .children()
@@ -387,7 +387,7 @@ impl DomHandle {
     /// since we were created, or because you passed in a different model
     /// from the one that created us.)
     pub fn text(&self, model: &ComposerModel) -> String {
-        let node = model.inner.state.dom.lookup_node(self.inner.clone());
+        let node = model.inner.state.dom.lookup_node(&self.inner);
         match node {
             wysiwyg::DomNode::Container(_) => String::from(""),
             wysiwyg::DomNode::Text(node) => node.data().to_utf8(),
@@ -399,7 +399,7 @@ impl DomHandle {
     /// since we were created, or because you passed in a different model
     /// from the one that created us.)
     pub fn tag(&self, model: &ComposerModel) -> String {
-        let node = model.inner.state.dom.lookup_node(self.inner.clone());
+        let node = model.inner.state.dom.lookup_node(&self.inner);
         match node {
             wysiwyg::DomNode::Container(node) => node.name().to_utf8(),
             wysiwyg::DomNode::Text(_) => String::from("-text-"),

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -62,7 +62,7 @@ where
         range: SameNodeRange,
         format: InlineFormatType,
     ) {
-        let node = self.state.dom.lookup_node(range.node_handle.clone());
+        let node = self.state.dom.lookup_node(&range.node_handle);
         if let DomNode::Text(t) = node {
             let text = t.data();
             // TODO: can we be globally smart about not leaving empty text nodes ?
@@ -92,7 +92,7 @@ where
         let found_format_locations: Vec<&DomLocation> = locations
             .iter()
             .filter(|l| {
-                let node = self.state.dom.lookup_node(l.node_handle.clone());
+                let node = self.state.dom.lookup_node(&l.node_handle);
                 Self::is_format_node(node, format)
             })
             .collect();
@@ -217,14 +217,11 @@ where
         handle: DomHandle,
         format: &InlineFormatType,
     ) -> Option<DomHandle> {
-        if Self::is_format_node(dom.lookup_node(handle.clone()), format) {
+        if Self::is_format_node(dom.lookup_node(&handle), format) {
             Some(handle)
         } else if handle.has_parent() {
             let parent_handle = handle.parent_handle();
-            if Self::is_format_node(
-                dom.lookup_node(parent_handle.clone()),
-                format,
-            ) {
+            if Self::is_format_node(dom.lookup_node(&parent_handle), format) {
                 Some(parent_handle)
             } else {
                 Self::path_contains_format_node(dom, parent_handle, format)
@@ -264,7 +261,7 @@ where
     fn merge_formatting_node_with_siblings(&mut self, handle: DomHandle) {
         // If has next sibling, try to join it with the current node
         if let DomNode::Container(parent) =
-            self.state.dom.lookup_node(handle.parent_handle())
+            self.state.dom.lookup_node(&handle.parent_handle())
         {
             if parent.children().len() - handle.index_in_parent() > 1 {
                 self.join_format_node_with_prev(handle.next_sibling());

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -49,7 +49,7 @@ where
 
     fn set_link_same_node(&mut self, range: SameNodeRange, link: S) {
         // TODO: set link should be able to wrap container nodes, unlike formatting
-        let node = self.state.dom.lookup_node(range.node_handle.clone());
+        let node = self.state.dom.lookup_node(&range.node_handle);
         if let DomNode::Text(t) = node {
             let text = t.data();
             let before = slice_to(text, ..range.start_offset);

--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -127,7 +127,7 @@ where
     ) -> bool {
         let dom = &self.state.dom;
         if let (DomNode::Container(prev_node), DomNode::Container(next_node)) =
-            (dom.lookup_node(prev.clone()), dom.lookup_node(next.clone()))
+            (dom.lookup_node(&prev), dom.lookup_node(&next))
         {
             if let (
                 ContainerNodeKind::Formatting(prev_format),
@@ -160,8 +160,8 @@ where
                 continue;
             }
 
-            let start_i = dom.lookup_node(start_handle.clone());
-            let next_i = dom.lookup_node(next_handle.clone());
+            let start_i = dom.lookup_node(&start_handle);
+            let next_i = dom.lookup_node(&next_handle);
 
             match (start_i, next_i) {
                 (DomNode::Container(start_i), DomNode::Container(next_i)) => {
@@ -255,7 +255,7 @@ where
 
     fn find_struct_parent(&self, handle: &DomHandle) -> Option<DomHandle> {
         let parent_handle = handle.parent_handle();
-        let parent = self.state.dom.lookup_node(parent_handle.clone());
+        let parent = self.state.dom.lookup_node(&parent_handle);
         if parent.is_structure_node() && parent_handle.has_parent() {
             if let Some(parent_result) = self.find_struct_parent(&parent_handle)
             {
@@ -278,7 +278,7 @@ where
         let dom = &mut self.state.dom;
         let ret;
         let children = if let DomNode::Container(from_node) =
-            dom.lookup_node(from_handle.clone())
+            dom.lookup_node(&from_handle)
         {
             from_node.children().clone()
         } else {
@@ -329,7 +329,7 @@ where
     ) -> Option<DomHandle> {
         locations.find_map(|loc| {
             if let DomNode::Text(_) =
-                self.state.dom.lookup_node(loc.node_handle.clone())
+                self.state.dom.lookup_node(&loc.node_handle)
             {
                 Some(loc.node_handle.clone())
             } else {

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -39,7 +39,7 @@ where
         // do_backspace_in_list should only be called on a single location
         // as selection can be handled in standard do_backspace.
         assert_eq!(range.start_offset, range.end_offset);
-        let parent_node = self.state.dom.lookup_node(parent_handle.clone());
+        let parent_node = self.state.dom.lookup_node(&parent_handle);
         let list_node_handle = parent_node.handle().parent_handle();
         if let DomNode::Container(parent) = parent_node {
             if parent.is_empty_list_item() {
@@ -71,7 +71,7 @@ where
         assert_eq!(range.start_offset, range.end_offset);
         // Store current Dom
         self.push_state_to_history();
-        let parent_node = self.state.dom.lookup_node(parent_handle.clone());
+        let parent_node = self.state.dom.lookup_node(&parent_handle);
         let list_node_handle = parent_node.handle().parent_handle();
         if let DomNode::Container(parent) = parent_node {
             if parent.is_empty_list_item() {
@@ -103,7 +103,7 @@ where
                 if let Some(list_item_handle) = parent_list_item_handle {
                     let list_node_handle = list_item_handle.parent_handle();
                     let list_node =
-                        self.state.dom.lookup_node(list_node_handle.clone());
+                        self.state.dom.lookup_node(&list_node_handle);
                     if let DomNode::Container(list) = list_node {
                         if list.is_list_of_type(list_type.clone()) {
                             self.move_list_item_content_to_list_parent(
@@ -130,8 +130,7 @@ where
         &mut self,
         list_item_handle: DomHandle,
     ) -> ComposerUpdate<S> {
-        let list_item_node =
-            self.state.dom.lookup_node(list_item_handle.clone());
+        let list_item_node = self.state.dom.lookup_node(&list_item_handle);
         if let DomNode::Container(list_item) = list_item_node {
             let list_item_children = list_item.children().clone();
             let list_handle = list_item_handle.parent_handle();
@@ -181,8 +180,7 @@ where
         let range = self.state.dom.find_range(s, e);
         match range {
             Range::SameNode(range) => {
-                let node =
-                    self.state.dom.lookup_node(range.node_handle.clone());
+                let node = self.state.dom.lookup_node(&range.node_handle);
                 if let DomNode::Text(t) = node {
                     let text = t.data();
                     let index_in_parent = range.node_handle.index_in_parent();

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -64,7 +64,7 @@ where
         let mut text_locations: Vec<&DomLocation> = locations
             .iter()
             .filter(|l| {
-                let node = self.state.dom.lookup_node(l.node_handle.clone());
+                let node = self.state.dom.lookup_node(&l.node_handle);
                 node.is_text_node()
             })
             .collect();
@@ -90,7 +90,7 @@ where
         handle: DomHandle,
     ) -> HashSet<ToolbarButton> {
         let mut active_buttons = HashSet::new();
-        let node = self.state.dom.lookup_node(handle.clone());
+        let node = self.state.dom.lookup_node(&handle);
         if let DomNode::Container(container) = node {
             let active_button = Self::active_button_for_container(container);
             if let Some(button) = active_button {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -112,7 +112,7 @@ where
                 return None;
             }
             let parent_handle = node.handle().parent_handle();
-            let parent_node = dom.lookup_node(parent_handle.clone());
+            let parent_node = dom.lookup_node(&parent_handle);
 
             match parent_node {
                 DomNode::Text(_) => find_list_item(dom, parent_node),
@@ -126,12 +126,12 @@ where
             }
         }
 
-        find_list_item(self, self.lookup_node(child_handle))
+        find_list_item(self, self.lookup_node(&child_handle))
     }
 
     /// Find the node based on its handle.
     /// Panics if the handle is unset or invalid
-    pub fn lookup_node(&self, node_handle: DomHandle) -> &DomNode<S> {
+    pub fn lookup_node(&self, node_handle: &DomHandle) -> &DomNode<S> {
         // TODO: consider taking a reference to handle to avoid clones
         fn nth_child<S>(element: &ContainerNode<S>, idx: usize) -> &DomNode<S>
         where
@@ -297,8 +297,8 @@ mod test {
         let child1 = &dom.children()[1];
 
         // The handles point to the right nodes
-        assert_eq!(dom.lookup_node(child0.handle()), child0);
-        assert_eq!(dom.lookup_node(child1.handle()), child1);
+        assert_eq!(dom.lookup_node(&child0.handle()), child0);
+        assert_eq!(dom.lookup_node(&child1.handle()), child1);
     }
 
     #[test]
@@ -316,7 +316,7 @@ mod test {
         let handle = nested_node.handle();
 
         // Then we can look it up and find the same node
-        assert_eq!(dom.lookup_node(handle), nested_node);
+        assert_eq!(dom.lookup_node(&handle), nested_node);
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -110,7 +110,7 @@ fn do_find_pos<S>(
 where
     S: UnicodeString,
 {
-    let node = dom.lookup_node(node_handle.clone());
+    let node = dom.lookup_node(&node_handle);
     let mut locations = Vec::new();
     if *offset > end {
         return locations;
@@ -248,9 +248,7 @@ mod test {
         range
             .locations
             .iter()
-            .map(|location| {
-                dom.lookup_node(location.node_handle.clone()).to_html()
-            })
+            .map(|location| dom.lookup_node(&location.node_handle).to_html())
             .collect()
     }
 
@@ -336,7 +334,7 @@ mod test {
             assert_eq!(range.start_offset, 4);
             assert_eq!(range.end_offset, 7);
 
-            if let DomNode::Text(t) = d.lookup_node(range.node_handle.clone()) {
+            if let DomNode::Text(t) = d.lookup_node(&range.node_handle) {
                 assert_eq!(*t.data(), utf16("foo bar baz"));
             } else {
                 panic!("Should have been a text node!")
@@ -357,7 +355,7 @@ mod test {
             assert_eq!(range.start_offset, 4);
             assert_eq!(range.end_offset, 11);
 
-            if let DomNode::Text(t) = d.lookup_node(range.node_handle.clone()) {
+            if let DomNode::Text(t) = d.lookup_node(&range.node_handle) {
                 assert_eq!(*t.data(), utf16("foo bar baz"));
             } else {
                 panic!("Should have been a text node!")
@@ -378,7 +376,7 @@ mod test {
             assert_eq!(range.start_offset, 1);
             assert_eq!(range.end_offset, 2);
 
-            if let DomNode::Text(t) = d.lookup_node(range.node_handle.clone()) {
+            if let DomNode::Text(t) = d.lookup_node(&range.node_handle) {
                 assert_eq!(*t.data(), utf16("bar"));
             } else {
                 panic!("Should have been a text node!")


### PR DESCRIPTION
I would like Dom.lookup_node and Dom.lookup_node_mut to take an argument of type &DomHandle instead of DomHandle.

Then everywhere they are called, we don't need to call handle.clone() before we call them. Instead just &handle.