### PR TITLE
Use reference in lookup_node_mut

### DIFF
--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -75,8 +75,7 @@ where
                 let child_index =
                     handle.raw().last().expect("Text node can't be root!");
                 let parent_handle = handle.parent_handle();
-                let mut parent =
-                    self.state.dom.lookup_node_mut(parent_handle.clone());
+                let mut parent = self.state.dom.lookup_node_mut(&parent_handle);
                 match &mut parent {
                     DomNode::Container(parent) => {
                         parent.remove_child(*child_index);

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -184,7 +184,7 @@ impl ComposerModel<Utf16String> {
         // Modify the text nodes to a {, } and |
         match range {
             Range::SameNode(range) => {
-                let mut node = dom.lookup_node_mut(range.node_handle.clone());
+                let mut node = dom.lookup_node_mut(&range.node_handle);
                 match &mut node {
                     DomNode::Container(_) => (), // Ignore - model is empty
                     DomNode::Text(n) => update_text_node_with_cursor(n, range),
@@ -385,7 +385,7 @@ fn write_selection_multi(
         SelectionWritingState::new(start, end, dom.document().text_len());
 
     for location in range.locations {
-        let mut node = dom.lookup_node_mut(location.node_handle.clone());
+        let mut node = dom.lookup_node_mut(&location.node_handle);
         match &mut node {
             DomNode::Container(_) => {}
             DomNode::Text(n) => {

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -161,7 +161,7 @@ where
                 if let DomNode::Container(parent) = self
                     .state
                     .dom
-                    .lookup_node_mut(loc.node_handle.parent_handle())
+                    .lookup_node_mut(&loc.node_handle.parent_handle())
                 {
                     let index = loc.node_handle.index_in_parent();
                     let node = parent.remove_child(index);

--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -202,12 +202,12 @@ where
                     new_data.push_string(&next_i.data());
                     let text_node = DomNode::new_text(new_data);
                     if let DomNode::Container(old_parent) =
-                        dom.lookup_node_mut(next_handle.parent_handle())
+                        dom.lookup_node_mut(&next_handle.parent_handle())
                     {
                         old_parent.remove_child(next_handle.index_in_parent());
                     }
                     if let DomNode::Container(parent) =
-                        dom.lookup_node_mut(start_handle.parent_handle())
+                        dom.lookup_node_mut(&start_handle.parent_handle())
                     {
                         parent.replace_child(
                             start_handle.index_in_parent(),
@@ -285,9 +285,7 @@ where
             panic!("Source node must be a ContainerNode");
         };
 
-        if let DomNode::Container(to_node) =
-            dom.lookup_node_mut(to_handle.clone())
-        {
+        if let DomNode::Container(to_node) = dom.lookup_node_mut(&to_handle) {
             ret = to_node.children().len();
             for c in children {
                 to_node.append_child(c);
@@ -297,7 +295,7 @@ where
         }
 
         if let DomNode::Container(parent) =
-            dom.lookup_node_mut(from_handle.parent_handle())
+            dom.lookup_node_mut(&from_handle.parent_handle())
         {
             parent.remove_child(from_handle.index_in_parent());
         } else {

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -137,7 +137,7 @@ where
             let list_index_in_parent = list_handle.index_in_parent();
             let list_parent_handle = list_handle.parent_handle();
             let list_parent_node =
-                self.state.dom.lookup_node_mut(list_parent_handle);
+                self.state.dom.lookup_node_mut(&list_parent_handle);
             if let DomNode::Container(list_parent) = list_parent_node {
                 for child in list_item_children.iter().rev() {
                     list_parent
@@ -148,7 +148,7 @@ where
             }
 
             let list_item_index_in_parent = list_item_handle.index_in_parent();
-            let list_node = self.state.dom.lookup_node_mut(list_handle);
+            let list_node = self.state.dom.lookup_node_mut(&list_handle);
             if let DomNode::Container(list) = list_node {
                 list.remove_child(list_item_index_in_parent);
             } else {
@@ -166,7 +166,7 @@ where
         list_handle: DomHandle,
         list_type: ListType,
     ) -> ComposerUpdate<S> {
-        let list_node = self.state.dom.lookup_node_mut(list_handle);
+        let list_node = self.state.dom.lookup_node_mut(&list_handle);
         if let DomNode::Container(list) = list_node {
             list.set_list_type(list_type);
         }
@@ -192,7 +192,7 @@ where
                     if index_in_parent > 0 {
                         let previous_handle = range.node_handle.prev_sibling();
                         let previous_node =
-                            self.state.dom.lookup_node_mut(previous_handle);
+                            self.state.dom.lookup_node_mut(&previous_handle);
                         if let DomNode::Container(previous) = previous_node {
                             if previous.is_list_of_type(list_type.clone()) {
                                 previous.append_child(list_item);
@@ -201,7 +201,7 @@ where
                                 let parent_node = self
                                     .state
                                     .dom
-                                    .lookup_node_mut(parent_node_handle);
+                                    .lookup_node_mut(&parent_node_handle);
                                 if let DomNode::Container(parent) = parent_node
                                 {
                                     parent.remove_child(index_in_parent);
@@ -260,14 +260,14 @@ where
         location: usize,
         range: SameNodeRange,
     ) {
-        let text_node = self.state.dom.lookup_node_mut(range.node_handle);
+        let text_node = self.state.dom.lookup_node_mut(&range.node_handle);
         if let DomNode::Text(ref mut t) = text_node {
             let text = t.data();
             // TODO: should slice container nodes between li and text node as well
             let new_text = slice_to(text, ..range.start_offset);
             let new_li_text = slice_from(text, range.end_offset..);
             t.set_data(new_text);
-            let list_node = self.state.dom.lookup_node_mut(handle);
+            let list_node = self.state.dom.lookup_node_mut(&handle);
             if let DomNode::Container(list) = list_node {
                 let add_zwsp = new_li_text.len() == 0;
                 list.append_child(DomNode::new_list_item(
@@ -293,13 +293,14 @@ where
         li_index: usize,
         insert_trailing_text_node: bool,
     ) {
-        let list_node = self.state.dom.lookup_node_mut(list_handle.clone());
+        let list_node = self.state.dom.lookup_node_mut(&list_handle);
         if let DomNode::Container(list) = list_node {
             let list_len = list.to_raw_text().len();
             let li_len = list.children()[li_index].to_raw_text().len();
             if list.children().len() == 1 {
                 let parent_handle = list_handle.parent_handle();
-                let parent_node = self.state.dom.lookup_node_mut(parent_handle);
+                let parent_node =
+                    self.state.dom.lookup_node_mut(&parent_handle);
                 if let DomNode::Container(parent) = parent_node {
                     parent.remove_child(list_handle.index_in_parent());
                     if parent.children().len() == 0 {
@@ -317,7 +318,7 @@ where
                 if insert_trailing_text_node {
                     let parent_handle = list_handle.parent_handle();
                     let parent_node =
-                        self.state.dom.lookup_node_mut(parent_handle);
+                        self.state.dom.lookup_node_mut(&parent_handle);
                     if let DomNode::Container(parent) = parent_node {
                         // TODO: should probably append a paragraph instead
                         parent.append_child(DomNode::new_text(S::from_str(

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -103,7 +103,7 @@ where
 
     fn replace_same_node(&mut self, range: SameNodeRange, new_text: S) {
         // TODO: remove SameNode and NoNode?
-        let node = self.state.dom.lookup_node_mut(range.node_handle);
+        let node = self.state.dom.lookup_node_mut(&range.node_handle);
         if let DomNode::Text(ref mut t) = node {
             let text = t.data();
             let mut n = slice_to(text, ..range.start_offset);
@@ -140,8 +140,7 @@ where
         let mut to_delete = Vec::new();
         let mut first_text_node = true;
         for loc in range.into_iter() {
-            let mut node =
-                self.state.dom.lookup_node_mut(loc.node_handle.clone());
+            let mut node = self.state.dom.lookup_node_mut(&loc.node_handle);
             match &mut node {
                 DomNode::Container(_) => {
                     // Nothing to do for container nodes

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -79,7 +79,7 @@ where
         node_handle: DomHandle,
         nodes: Vec<DomNode<S>>,
     ) -> Vec<DomHandle> {
-        let parent_node = self.lookup_node_mut(node_handle.parent_handle());
+        let parent_node = self.lookup_node_mut(&node_handle.parent_handle());
         let index = node_handle.index_in_parent();
         match parent_node {
             DomNode::Text(_n) => panic!("Text nodes can't have children"),
@@ -166,7 +166,7 @@ where
     /// Panics if the handle is invalid or unset
     pub fn lookup_node_mut(
         &mut self,
-        node_handle: DomHandle,
+        node_handle: &DomHandle,
     ) -> &mut DomNode<S> {
         fn nth_child<S>(
             element: &mut ContainerNode<S>,


### PR DESCRIPTION
I would like Dom.lookup_node and Dom.lookup_node_mut to take an argument of type &DomHandle instead of DomHandle.

Then everywhere they are called, we don't need to call handle.clone() before we call them. Instead just &handle.