### PR TITLE
Fix list focus when the editor is empty

### DIFF
--- a/platforms/web/example/test.js
+++ b/platforms/web/example/test.js
@@ -146,7 +146,14 @@ run_tests([
         assert_eq(offset, 0);
     }},
 
-    { name: "node_and_offset finds inside an list", test: () => {
+    { name: "node_and_offset finds inside two  empty list", test: () => {
+        editor.innerHTML = "<ul><li><li></ul><li><li></ul>";
+        let { node, offset } = node_and_offset(editor, 0);
+        assert_same(node, editor.childNodes[0].childNodes[0]);
+        assert_eq(offset, 0);
+    }},
+
+    { name: "node_and_offset finds inside a list", test: () => {
         editor.innerHTML = "<ul><li>foo<li></ul>";
         let { node, offset } = node_and_offset(editor, 1);
         assert_same(node, editor.childNodes[0].childNodes[0].childNodes[0]);

--- a/platforms/web/example/test.js
+++ b/platforms/web/example/test.js
@@ -100,6 +100,20 @@ run_tests([
         assert_eq(offset, 1);
     }},
 
+    { name: "node_and_offset finds inside an empty list", test: () => {
+        editor.innerHTML = "<ul><li><li></ul>";
+        let { node, offset } = node_and_offset(editor, 0);
+        assert_same(node, editor.childNodes[0].childNodes[0]);
+        assert_eq(offset, 0);
+    }},
+
+    { name: "node_and_offset finds inside an list", test: () => {
+        editor.innerHTML = "<ul><li>foo<li></ul>";
+        let { node, offset } = node_and_offset(editor, 1);
+        assert_same(node, editor.childNodes[0].childNodes[0].childNodes[0]);
+        assert_eq(offset, 1);
+    }},
+
     { name: "codeunit_count ASCII", test: () => {
         editor.innerHTML = "abcdefgh";
         let textNode = editor.childNodes[0];

--- a/platforms/web/example/wysiwyg.js
+++ b/platforms/web/example/wysiwyg.js
@@ -358,7 +358,8 @@ function codeunit_count(editor, node, offset) {
  * A "codeunit" here means a UTF-16 code unit.
  */
 function node_and_offset(current_node, codeunits) {
-    if (current_node.nodeType === Node.TEXT_NODE) {
+    const isEmptyList = current_node.nodeName === 'LI' && !current_node.hasChildNodes()
+    if (current_node.nodeType === Node.TEXT_NODE || isEmptyList) {
         if (codeunits <= current_node.textContent.length) {
             return { node: current_node, offset: codeunits };
         } else {


### PR DESCRIPTION
Clicking "list" when the composer is empty loses focus. Focus should stay in the composer.