### PR TITLE
Web: add button for inline code

### DIFF
--- a/platforms/web/example/index.html
+++ b/platforms/web/example/index.html
@@ -134,22 +134,23 @@ h2 {
 <div>
 <div class="editor_container">
 <div class="editor_toolbar">
-    <button id="button_undo" href="#"><img src="images/undo.svg"/></button>
-    <button id="button_redo" href="#"><img src="images/redo.svg"/></button>
-    <button id="button_bold" href="#"><img src="images/bold.svg"/></button>
-    <button id="button_italic" href="#"><img src="images/italic.svg"/></button>
-    <button id="button_underline" href="#">
+    <button id="button_undo" type="button"><img src="images/undo.svg"/></button>
+    <button id="button_redo" type="button"><img src="images/redo.svg"/></button>
+    <button id="button_bold" type="button"><img src="images/bold.svg"/></button>
+    <button id="button_italic" type="button"><img src="images/italic.svg"/></button>
+    <button id="button_underline" type="button">
         <img src="images/underline.svg"/>
     </button>
-    <button id="button_strike_through" href="#">
+    <button id="button_strike_through" type="button">
         <img src="images/strike_through.svg"/>
     </button>
-    <button id="button_list_unordered" href="#">
+    <button id="button_list_unordered" type="button">
         <img src="images/list-unordered.svg"/>
     </button>
-    <button id="button_list_ordered" href="#">
+    <button id="button_list_ordered" type="button">
         <img src="images/list-ordered.svg"/>
     </button>
+    <button id="button_inline_code" type="button">&lt/&gt</button>
 </div>
 <div class="editor" contenteditable="true" role="textbox"><br/></div>
 </div>

--- a/platforms/web/example/wysiwyg.js
+++ b/platforms/web/example/wysiwyg.js
@@ -14,6 +14,7 @@ let button_redo;
 let button_strike_through;
 let button_underline;
 let button_undo;
+let button_inline_code;
 let dom;
 let testcase;
 let reset_testcase;
@@ -30,6 +31,7 @@ async function wysiwyg_run() {
     editor = document.getElementsByClassName('editor')[0];
     editor.addEventListener('input', editor_input);
     editor.addEventListener("keydown", editor_keydown);
+    editor.addEventListener('formatBlock', editor_formatBlock);
 
     button_bold = document.getElementById('button_bold');
     button_bold.addEventListener('click', button_bold_click);
@@ -61,6 +63,9 @@ async function wysiwyg_run() {
 
     button_undo = document.getElementById('button_undo');
     button_undo.addEventListener('click', button_undo_click);
+
+    button_inline_code = document.getElementById('button_inline_code')
+    button_inline_code.addEventListener('click', button_inline_code_click)
 
     reset_testcase = document.getElementById('reset_testcase');
     reset_testcase.addEventListener('click', resetTestcase);
@@ -96,6 +101,10 @@ function editor_input(e) {
         }
         refresh_dom();
     }
+}
+
+function editor_formatBlock(e) {
+    editor_input({inputType: e.detail.blockType})
 }
 
 function refresh_dom() {
@@ -221,6 +230,15 @@ function button_underline_click(e) {
 
 function button_undo_click(e) {
     send_input(e, "historyUndo");
+}
+
+function button_inline_code_click(e) {
+    sendFormatBlockEvent(e, 'formatInlineCode')
+}
+
+function sendFormatBlockEvent(e, blockType) {
+    e.preventDefault();
+    editor.dispatchEvent(new CustomEvent('formatBlock', {detail: {blockType}}))
 }
 
 function get_current_selection() {
@@ -564,6 +582,8 @@ function process_input(e) {
             return action(composer_model.strike_through(), "strike_through");
         case "formatUnderline":
             return action(composer_model.underline(), "underline");
+        case "formatInlineCode":
+            return action(composer_model.inline_code(), "inline_code");
         case "historyRedo":
             return action(composer_model.redo(), "redo");
         case "historyUndo":


### PR DESCRIPTION
Add a button in the toolbar for inline code

The code [code html element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code) doesn't have a input type (https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes) like bold, italic...

So instead of using an input event (no inputType is fitting), I'm using a custom event.

The main drawback is that the code tag is not inserted by the browser but by the return of the composer model.

Nice sandbox to play with input event https://d-toybox.com/studio/lib/input_event_viewer.html