### PR TITLE
Allow creation of empty format nodes

### DIFF
--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -149,7 +149,10 @@ where
     let container_end = *offset;
     let container_node_len = container_end - container_start;
     // We never want to return the root node
-    if !node.handle().is_root() {
+    if container_end >= start
+        && container_start <= end
+        && !node.handle().is_root()
+    {
         let start_offset = max(start, container_start) - container_start;
         let end_offset = min(end, container_end) - container_start;
         results.push(DomLocation {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -123,6 +123,25 @@ where
             _ => false,
         }
     }
+
+    pub(crate) fn is_placeholder_text_node(&self) -> bool {
+        match self {
+            DomNode::Text(n) => {
+                n.data().len() == 1 && n.data().to_utf8() == "\u{200b}"
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn has_only_placeholder_text_child(&self) -> bool {
+        match self {
+            DomNode::Container(n) => {
+                n.children().len() == 1
+                    && n.children().first().unwrap().is_placeholder_text_node()
+            }
+            _ => false,
+        }
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -141,7 +141,7 @@ class EditorEditText : TextInputEditText {
         if (result != null) {
             editableText.clear()
             editableText.replace(0, editableText.length, result.text)
-            setSelectionFromComposerUpdate(result.selection.last)
+            setSelectionFromComposerUpdate(result.selection.first, result.selection.last)
         }
         return result != null
     }


### PR DESCRIPTION
Empty text nodes could only be created at the index 0 of the composer before. With this workaround they can be created anywhere.