### PR TITLE
[iOS] Remove workaround for linebreaks

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -161,7 +161,6 @@ private extension WysiwygComposerViewModel {
                          endUtf16Codeunit: let end):
             let html = String(utf16CodeUnits: codeUnits,
                               count: codeUnits.count)
-                .replacingOccurrences(of: "\n", with: "<br>")
             do {
                 let attributed = try NSAttributedString(html: html)
                 // FIXME: handle error for out of bounds index


### PR DESCRIPTION
Removes a now unnecessary workaround that replaced "\n" with `br` tags