### PR TITLE
[iOS] Fix keyboard autocomplete

### DIFF
--- a/platforms/ios/example/Wysiwyg.xcodeproj/xcshareddata/xcschemes/Wysiwyg.xcscheme
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/xcshareddata/xcschemes/Wysiwyg.xcscheme
@@ -38,6 +38,11 @@
                BlueprintName = "WysiwygComposerTests"
                ReferencedContainer = "container:../lib/WysiwygComposer">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "WysiwygComposerViewModelTests/testStandardTextInput()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -42,8 +42,10 @@ struct WysiwygComposerView: UIViewRepresentable {
         Logger.textView.logDebug([content.logAttributedSelection,
                                   content.logText],
                                  functionName: #function)
-        uiView.attributedText = content.attributed
-        uiView.selectedRange = content.attributedSelection
+        uiView.performWithoutDelegate {
+            uiView.attributedText = content.attributed
+            uiView.selectedRange = content.attributedSelection
+        }
         context.coordinator.didUpdateText(uiView)
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/String.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/String.swift
@@ -1,0 +1,24 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+extension String {
+    /// Returns length of the string in UTF16 code units.
+    var utf16Length: Int {
+        return (self as NSString).length
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -1,0 +1,30 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+extension UITextView {
+    /// Perform an action while temporary removing the text view delegate to avoid subsequent updates.
+    ///
+    /// - Parameters:
+    ///   - block: Code block to perform.
+    func performWithoutDelegate(block: () -> Void) {
+        let myDelegate = self.delegate
+        self.delegate = nil
+        block()
+        self.delegate = myDelegate
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -19,9 +19,8 @@ import Combine
 @testable import WysiwygComposer
 
 final class WysiwygComposerViewModelTests: XCTestCase {
-    private let viewModel = WysiwygComposerViewModel()
-
     func testIsContentEmpty() throws {
+        let viewModel = WysiwygComposerViewModel()
         XCTAssertTrue(viewModel.isContentEmpty)
 
         let expectFalse = self.expectation(description: "Await isContentEmpty false")
@@ -57,5 +56,82 @@ final class WysiwygComposerViewModelTests: XCTestCase {
 
         wait(for: [expectTrue], timeout: 2.0)
         cancellableTrue.cancel()
+    }
+
+    func testKeyboardAutocompleteWhitespaceMissSelection() throws {
+        let viewModel = WysiwygComposerViewModel()
+        // Selection that will get block by the view model to avoid wrong OS inputs.
+        let missSelectionRange = NSRange(location: 8, length: 0)
+
+        viewModel.replaceText(NSAttributedString(string: ""),
+                              range: .zero,
+                              replacementText: "Autocomp")
+        // Simulate the first input from a keyboard autocomplete.
+        viewModel.replaceText(NSAttributedString(string: "Autocomp"),
+                              range: NSRange(location: 0, length: 8),
+                              replacementText: "Autocomplete")
+        // Miss selection range is locked
+        viewModel.select(text: NSAttributedString(string: "Autocomp"),
+                         range: missSelectionRange)
+        XCTAssertNotEqual(viewModel.content.attributedSelection,
+                          missSelectionRange)
+        // Simulate the second input from a keyboard autocomplete (e.g. with wrong location).
+        viewModel.replaceText(NSAttributedString(string: "Autocomp"),
+                              range: missSelectionRange,
+                              replacementText: " ")
+        // Content is correct and the cursor is at the expected location
+        XCTAssertEqual(viewModel.content.plainText,
+                       "Autocomplete ")
+        XCTAssertEqual(viewModel.content.attributedSelection,
+                       NSRange(location: 13, length: 0))
+        // Previous miss selection range is now selectable
+        viewModel.select(text: NSAttributedString(string: "Autocomplete "),
+                         range: missSelectionRange)
+        XCTAssertEqual(viewModel.content.attributedSelection,
+                       missSelectionRange)
+    }
+
+    func testKeyboardReplaceWithMissSelection() throws {
+        let viewModel = WysiwygComposerViewModel()
+        // Selection that will get block by the view model to avoid wrong OS inputs.
+        let missSelectionRange = NSRange(location: 13, length: 0)
+
+        viewModel.replaceText(NSAttributedString(string: ""),
+                              range: .zero,
+                              replacementText: "Some incorect text")
+        // Simulate the first input from a keyboard replace.
+        viewModel.replaceText(NSAttributedString(string: "Some incorect text"),
+                              range: NSRange(location: 5, length: 8),
+                              replacementText: "incorrect")
+        // Miss selection range is locked
+        viewModel.select(text: NSAttributedString(string: "Autocomp"),
+                         range: missSelectionRange)
+        XCTAssertNotEqual(viewModel.content.attributedSelection,
+                          missSelectionRange)
+        // Simulate the second input from a keyboard replace (e.g. with wrong location).
+        viewModel.replaceText(NSAttributedString(string: "Some incorect text"),
+                              range: missSelectionRange,
+                              replacementText: "")
+        // Content is correct and the cursor is at the expected location
+        XCTAssertEqual(viewModel.content.plainText,
+                       "Some incorrect text")
+        XCTAssertEqual(viewModel.content.attributedSelection,
+                       NSRange(location: 14, length: 0))
+        // Previous miss selection range is now selectable
+        viewModel.select(text: NSAttributedString(string: "Some incorrect text"),
+                         range: missSelectionRange)
+        XCTAssertEqual(viewModel.content.attributedSelection,
+                       missSelectionRange)
+    }
+
+    func testStandardTextInput() throws {
+        // FIXME: fix unselectable range issue on standard text input and re-enable this
+        let viewModel = WysiwygComposerViewModel()
+        viewModel.replaceText(NSAttributedString(string: ""),
+                              range: .zero,
+                              replacementText: "A")
+        viewModel.select(text: NSAttributedString(string: "A"),
+                         range: .zero)
+        XCTAssertEqual(viewModel.content.attributedSelection, .zero)
     }
 }


### PR DESCRIPTION
Fixes most issues on iOS keyboard autocompletion.
There is still a pending issue on standard text input with a specific location that is blocked for selection in some cases.