### PR TITLE
Support multiple whitespaces

### DIFF
--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -146,8 +146,8 @@ impl ComposerModel<Utf16String> {
     /// See [ComposerModel::from_example_format] for the format used.
     pub fn to_example_format(&self) -> String {
         // Clone the model because we will modify it to add selection markers
-        let state = self.state.clone();
-        let dom = state.dom;
+        let state = &self.state;
+        let dom = &state.dom;
 
         let mut formatter = HtmlFormatter::new();
 
@@ -155,9 +155,9 @@ impl ComposerModel<Utf16String> {
         let range = dom.find_range(state.start.into(), state.end.into());
 
         // Modify the text nodes to add {, } and |
-        let selection_start = self.state.start.into();
-        let selection_end = self.state.end.into();
-        let doc_length = self.state.dom.document().text_len();
+        let selection_start = state.start.into();
+        let selection_end = state.end.into();
+        let doc_length = dom.document().text_len();
         let root = dom.lookup_node(&dom.document_handle());
         let state = SelectionWritingState::new(
             selection_start,

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -472,7 +472,7 @@ mod test {
         model.format(InlineFormatType::Bold);
         assert_eq!(
             model.state.dom.to_string(),
-            "<strong>hello </strong><i><strong>wor</strong>ld</i>"
+            "<strong>hello\u{a0}</strong><i><strong>wor</strong>ld</i>"
         );
     }
 
@@ -555,6 +555,6 @@ mod test {
         model.bold();
         assert_eq!(tx(&model), "AAA <strong>{~}|</strong>");
         model.bold();
-        assert_eq!(tx(&model), "AAA |");
+        assert_eq!(tx(&model), "AAA&nbsp;|");
     }
 }

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -472,7 +472,7 @@ mod test {
         model.format(InlineFormatType::Bold);
         assert_eq!(
             model.state.dom.to_string(),
-            "<strong>hello\u{a0}</strong><i><strong>wor</strong>ld</i>"
+            "<strong>hello&nbsp;</strong><i><strong>wor</strong>ld</i>"
         );
     }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -334,8 +334,10 @@ where
         &self,
         f: &mut HtmlFormatter<S>,
         selection_writer: Option<&mut SelectionWriter>,
+        is_last_node_in_parent: bool,
     ) {
-        self.document.fmt_html(f, selection_writer)
+        self.document
+            .fmt_html(f, selection_writer, is_last_node_in_parent)
     }
 }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -15,7 +15,9 @@
 use std::fmt::Display;
 
 use crate::composer_model::base::{slice_from, slice_to};
+use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
+use crate::dom::HtmlFormatter;
 use crate::dom::{
     find_range, to_raw_text::ToRawText, DomHandle, Range, ToTree, UnicodeString,
 };
@@ -328,8 +330,12 @@ impl<S> ToHtml<S> for Dom<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut super::HtmlFormatter<S>) {
-        self.document.fmt_html(f)
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        selection_writer: Option<&mut SelectionWriter>,
+    ) {
+        self.document.fmt_html(f, selection_writer)
     }
 }
 

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -224,7 +224,7 @@ mod test {
     use widestring::Utf16String;
 
     use super::*;
-    use crate::tests::testutils_composer_model::cm;
+    use crate::tests::testutils_composer_model::{cm, restore_whitespace_u16};
     use crate::tests::testutils_conversion::utf16;
     use crate::tests::testutils_dom::{b, dom, tn};
     use crate::ToHtml;
@@ -253,7 +253,11 @@ mod test {
         range
             .locations
             .iter()
-            .map(|location| dom.lookup_node(&location.node_handle).to_html())
+            .map(|location| {
+                restore_whitespace_u16(
+                    &dom.lookup_node(&location.node_handle).to_html(),
+                )
+            })
             .collect()
     }
 

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Range;
-
-use crate::composer_model::example_format::SelectionWriter;
-use crate::{DomNode, ToHtml};
+use std::ops::{Range, RangeFrom};
 
 use super::UnicodeString;
 
@@ -47,6 +44,14 @@ where
         }
     }
 
+    pub fn chars_at(&self, range: Range<usize>) -> &[S::CodeUnit] {
+        &self.chars[range]
+    }
+
+    pub fn chars_from(&self, range: RangeFrom<usize>) -> &[S::CodeUnit] {
+        &self.chars[range]
+    }
+
     pub fn write_char(&mut self, c: HtmlChar) {
         self.chars.push(match c {
             HtmlChar::Equal => self.known_char_data.equal.clone(),
@@ -64,8 +69,20 @@ where
         self.chars.extend_from_slice(slice);
     }
 
+    pub fn write_char_at(&mut self, pos: usize, char: S::CodeUnit) {
+        self.chars.insert(pos, char);
+    }
+
     pub fn write_at(&mut self, pos: usize, slice: &[S::CodeUnit]) {
-        self.chars.splice(pos..pos, slice.to_vec());
+        self.write_at_range(pos..pos, slice);
+    }
+
+    pub fn write_at_range(
+        &mut self,
+        range: Range<usize>,
+        slice: &[S::CodeUnit],
+    ) {
+        self.chars.splice(range, slice.to_vec());
     }
 
     pub fn write_iter(&mut self, chars: impl Iterator<Item = S::CodeUnit>) {
@@ -76,46 +93,14 @@ where
         self.chars.extend(chars)
     }
 
-    pub fn write_node(
-        &mut self,
-        node: &DomNode<S>,
-        is_last: bool,
-        selection_writer: Option<&mut SelectionWriter>,
-    ) {
-        let cur_pos = self.chars.len();
-        let mut ret: Vec<S::CodeUnit> = Vec::new();
-        match node {
-            DomNode::Text(t) => {
-                let mut post_processed_data = String::new();
-                html_escape::encode_text_to_string(
-                    t.data().to_utf8(),
-                    &mut post_processed_data,
-                );
-                handle_several_whitespaces(&mut post_processed_data, is_last);
-                self.write(S::from_str(&post_processed_data).as_slice());
-                if let Some(sel_writer) = selection_writer {
-                    sel_writer.write_node(self, cur_pos, node);
-                }
-            }
-            DomNode::Container(c) => {
-                c.fmt_html(self, selection_writer);
-            }
-            DomNode::LineBreak(n) => {
-                ret.push(S::c_from_char('<'));
-                ret.extend_from_slice(n.name().as_slice());
-                ret.push(S::c_from_char(' '));
-                ret.push(S::c_from_char('/'));
-                ret.push(S::c_from_char('>'));
-                self.write_vec(ret);
-                if let Some(sel_writer) = selection_writer {
-                    sel_writer.write_node(self, cur_pos, node);
-                }
-            }
-        }
+    pub fn finish(self) -> S {
+        let ret =
+            S::from_vec(self.chars).expect("Unable to convert to unicode!");
+        S::from_str(&ret.to_utf8().replace("\u{A0}", "&nbsp;"))
     }
 
-    pub fn finish(self) -> S {
-        S::from_vec(self.chars).expect("Unable to convert to unicode!")
+    pub fn len(&self) -> usize {
+        self.chars.len()
     }
 }
 
@@ -144,41 +129,5 @@ where
             quote: S::c_from_char('"'),
             space: S::c_from_char(' '),
         }
-    }
-}
-
-fn handle_several_whitespaces(html: &mut String, is_last: bool) {
-    let mut ranges_to_replace = Vec::new();
-    let mut current_range: Range<usize> = usize::MAX..usize::MAX;
-    let mut whitespaces: usize = 0;
-    let mut needs_to_replace = false;
-    for (i, c) in html.chars().enumerate() {
-        if c == ' ' || c == '\u{A0}' {
-            if c == ' ' {
-                needs_to_replace = true;
-            }
-            if current_range.start == usize::MAX {
-                whitespaces = 1;
-                current_range.start = i;
-            } else {
-                whitespaces += 1;
-            }
-        } else {
-            if needs_to_replace && whitespaces > 1 {
-                current_range.end = i;
-                ranges_to_replace.push((current_range.clone(), whitespaces));
-            }
-            needs_to_replace = false;
-            current_range = usize::MAX..usize::MAX;
-        }
-    }
-    if is_last && needs_to_replace {
-        current_range.end = html.len();
-        ranges_to_replace.push((current_range.clone(), whitespaces));
-    }
-
-    for (range, whitespaces) in ranges_to_replace.iter().rev() {
-        let replacement: String = (0..*whitespaces).map(|_| '\u{A0}').collect();
-        html.replace_range(range.clone(), &replacement);
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -288,44 +288,45 @@ where
 {
     fn fmt_html(
         &self,
-        f: &mut HtmlFormatter<S>,
+        formatter: &mut HtmlFormatter<S>,
         selection_writer: Option<&mut SelectionWriter>,
+        _: bool,
     ) {
         let name = self.name();
         if !name.is_empty() {
-            f.write_char(HtmlChar::Lt);
-            f.write(name.as_slice());
+            formatter.write_char(HtmlChar::Lt);
+            formatter.write(name.as_slice());
             if let Some(attrs) = &self.attrs {
                 for attr in attrs {
-                    f.write_char(HtmlChar::Space);
+                    formatter.write_char(HtmlChar::Space);
                     let (attr_name, value) = attr;
-                    f.write(attr_name.as_slice());
-                    f.write_char(HtmlChar::Equal);
-                    f.write_char(HtmlChar::Quote);
-                    f.write(value.as_slice());
-                    f.write_char(HtmlChar::Quote);
+                    formatter.write(attr_name.as_slice());
+                    formatter.write_char(HtmlChar::Equal);
+                    formatter.write_char(HtmlChar::Quote);
+                    formatter.write(value.as_slice());
+                    formatter.write_char(HtmlChar::Quote);
                 }
             }
-            f.write_char(HtmlChar::Gt);
+            formatter.write_char(HtmlChar::Gt);
         }
 
         if let Some(w) = selection_writer {
             for (i, child) in self.children.iter().enumerate() {
                 let is_last = self.children().len() == i + 1;
-                f.write_node(child, is_last, Some(w));
+                child.fmt_html(formatter, Some(w), is_last);
             }
         } else {
             for (i, child) in self.children.iter().enumerate() {
                 let is_last = self.children().len() == i + 1;
-                f.write_node(child, is_last, None);
+                child.fmt_html(formatter, None, is_last);
             }
         }
 
         if !name.is_empty() {
-            f.write_char(HtmlChar::Lt);
-            f.write_char(HtmlChar::ForwardSlash);
-            f.write(name.as_slice());
-            f.write_char(HtmlChar::Gt);
+            formatter.write_char(HtmlChar::Lt);
+            formatter.write_char(HtmlChar::ForwardSlash);
+            formatter.write(name.as_slice());
+            formatter.write_char(HtmlChar::Gt);
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::nodes::dom_node::DomNode;
@@ -285,7 +286,11 @@ impl<S> ToHtml<S> for ContainerNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut HtmlFormatter<S>) {
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        selection_writer: Option<&mut SelectionWriter>,
+    ) {
         let name = self.name();
         if !name.is_empty() {
             f.write_char(HtmlChar::Lt);
@@ -304,8 +309,16 @@ where
             f.write_char(HtmlChar::Gt);
         }
 
-        for child in &self.children {
-            child.fmt_html(f);
+        if let Some(w) = selection_writer {
+            for (i, child) in self.children.iter().enumerate() {
+                let is_last = self.children().len() == i + 1;
+                f.write_node(child, is_last, Some(w));
+            }
+        } else {
+            for (i, child) in self.children.iter().enumerate() {
+                let is_last = self.children().len() == i + 1;
+                f.write_node(child, is_last, None);
+            }
         }
 
         if !name.is_empty() {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
@@ -148,11 +149,15 @@ impl<S> ToHtml<S> for DomNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut HtmlFormatter<S>) {
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        selection_writer: Option<&mut SelectionWriter>,
+    ) {
         match self {
-            DomNode::Container(s) => s.fmt_html(f),
-            DomNode::LineBreak(s) => s.fmt_html(f),
-            DomNode::Text(s) => s.fmt_html(f),
+            DomNode::Container(s) => s.fmt_html(f, selection_writer),
+            DomNode::LineBreak(s) => s.fmt_html(f, selection_writer),
+            DomNode::Text(s) => s.fmt_html(f, selection_writer),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -153,11 +153,18 @@ where
         &self,
         f: &mut HtmlFormatter<S>,
         selection_writer: Option<&mut SelectionWriter>,
+        is_last_node_in_parent: bool,
     ) {
         match self {
-            DomNode::Container(s) => s.fmt_html(f, selection_writer),
-            DomNode::LineBreak(s) => s.fmt_html(f, selection_writer),
-            DomNode::Text(s) => s.fmt_html(f, selection_writer),
+            DomNode::Container(s) => {
+                s.fmt_html(f, selection_writer, is_last_node_in_parent)
+            }
+            DomNode::LineBreak(s) => {
+                s.fmt_html(f, selection_writer, is_last_node_in_parent)
+            }
+            DomNode::Text(s) => {
+                s.fmt_html(f, selection_writer, is_last_node_in_parent)
+            }
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::example_format::SelectionWriter;
 use std::marker::PhantomData;
 
 use crate::dom::dom_handle::DomHandle;
@@ -67,7 +68,11 @@ impl<S> ToHtml<S> for LineBreakNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut HtmlFormatter<S>) {
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        _: Option<&mut SelectionWriter>,
+    ) {
         f.write_char(HtmlChar::Lt);
         f.write(self.name().as_slice());
         f.write_char(HtmlChar::Space);

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -71,13 +71,18 @@ where
     fn fmt_html(
         &self,
         f: &mut HtmlFormatter<S>,
-        _: Option<&mut SelectionWriter>,
+        selection_writer: Option<&mut SelectionWriter>,
+        _: bool,
     ) {
+        let cur_pos = f.len();
         f.write_char(HtmlChar::Lt);
         f.write(self.name().as_slice());
         f.write_char(HtmlChar::Space);
         f.write_char(HtmlChar::ForwardSlash);
         f.write_char(HtmlChar::Gt);
+        if let Some(sel_writer) = selection_writer {
+            sel_writer.write_selection_line_break_node(f, cur_pos, self);
+        }
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::example_format::SelectionWriter;
+use html_escape;
+
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::UnicodeString;
-
-use html_escape;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TextNode<S>
@@ -66,7 +67,11 @@ impl<S> ToHtml<S> for TextNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut HtmlFormatter<S>) {
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        _: Option<&mut SelectionWriter>,
+    ) {
         let string = self.data.to_utf8();
         let mut escaped = String::new();
         html_escape::encode_text_to_string(&string, &mut escaped);

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -211,6 +211,7 @@ mod test {
     use speculoos::{assert_that, AssertionFailure, Spec};
     use widestring::Utf16String;
 
+    use crate::tests::testutils_composer_model::restore_whitespace;
     use crate::{dom::UnicodeString, ToHtml};
 
     use super::parse;
@@ -226,7 +227,7 @@ mod test {
         fn roundtrips(&self) {
             let subject = self.subject.as_ref();
             let dom = parse::<Utf16String>(subject).unwrap();
-            let output = dom.to_html().to_utf8();
+            let output = restore_whitespace(&dom.to_html().to_utf8());
             if output != subject {
                 AssertionFailure::from_spec(self)
                     .with_expected(String::from(subject))

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -92,12 +92,22 @@ impl DomLocation {
 
     /// Whether the selection starts at this location or not
     pub fn is_start(&self) -> bool {
-        self.end_offset == self.length
+        let end_offset = if self.start_offset < self.end_offset {
+            self.end_offset
+        } else {
+            self.start_offset
+        };
+        end_offset == self.length
     }
 
     /// Whether the selection ends at this location or not
     pub fn is_end(&self) -> bool {
-        self.start_offset == 0
+        let start_offset = if self.start_offset < self.end_offset {
+            self.start_offset
+        } else {
+            self.end_offset
+        };
+        start_offset == 0
     }
 
     /// Whether the selection completely covers this location

--- a/crates/wysiwyg/src/dom/to_html.rs
+++ b/crates/wysiwyg/src/dom/to_html.rs
@@ -23,13 +23,14 @@ where
 {
     fn fmt_html(
         &self,
-        f: &mut HtmlFormatter<S>,
+        formatter: &mut HtmlFormatter<S>,
         selection_writer: Option<&mut SelectionWriter>,
+        is_last_node_in_parent: bool,
     );
 
     fn to_html(&self) -> S {
         let mut f = HtmlFormatter::new();
-        self.fmt_html(&mut f, None);
+        self.fmt_html(&mut f, None, false);
         f.finish()
     }
 }

--- a/crates/wysiwyg/src/dom/to_html.rs
+++ b/crates/wysiwyg/src/dom/to_html.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::HtmlFormatter;
 
 use super::UnicodeString;
@@ -20,11 +21,15 @@ pub trait ToHtml<S>
 where
     S: UnicodeString,
 {
-    fn fmt_html(&self, f: &mut HtmlFormatter<S>);
+    fn fmt_html(
+        &self,
+        f: &mut HtmlFormatter<S>,
+        selection_writer: Option<&mut SelectionWriter>,
+    );
 
     fn to_html(&self) -> S {
         let mut f = HtmlFormatter::new();
-        self.fmt_html(&mut f);
+        self.fmt_html(&mut f, None);
         f.finish()
     }
 }

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -19,7 +19,7 @@ use widestring::{Utf16String, Utf32String};
 /// We implement this for String, Utf16String and Utf32String (from the
 /// widestring crate).
 pub trait UnicodeString: Clone + std::fmt::Debug + PartialEq {
-    type CodeUnit: Clone;
+    type CodeUnit: Clone + PartialEq;
 
     fn new() -> Self;
 

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -16,7 +16,7 @@
 
 use widestring::Utf16String;
 
-use crate::tests::testutils_composer_model::{cm, tx};
+use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
 use crate::tests::testutils_conversion::utf16;
 use crate::{ComposerModel, Location};
 
@@ -195,7 +195,7 @@ fn replacing_across_list_items_deletes_intervening_ones() {
         </ol>");
     replace_text(&mut model, "Z");
     assert_eq!(
-        tx(&model),
+        restore_whitespace(&tx(&model)),
         "<ol>
             <li>1Z|3</li>
             <li>44</li>
@@ -215,7 +215,7 @@ fn replacing_across_lists_joins_them() {
         </ol>");
     replace_text(&mut model, "Z");
     assert_eq!(
-        tx(&model),
+        restore_whitespace(&tx(&model)),
         "<ol>
             <li>1Z|4</li>
         </ol>"
@@ -248,6 +248,23 @@ fn replacing_a_selection_ending_br_with_a_character() {
     let mut model = cm("abc{def<br />}|ghi");
     replace_text(&mut model, "Z");
     assert_eq!(tx(&model), "abcZ|ghi");
+}
+
+#[test]
+fn multiple_spaces_translates_into_non_breakable_whitespaces() {
+    let mut model = cm("abc|");
+    replace_text(&mut model, " ");
+    assert_eq!(tx(&model), "abc&nbsp;|");
+    replace_text(&mut model, " ");
+    assert_eq!(tx(&model), "abc&nbsp;&nbsp;|");
+    replace_text(&mut model, " ");
+    assert_eq!(tx(&model), "abc&nbsp;&nbsp;&nbsp;|");
+}
+
+#[test]
+fn multiple_spaces_between_text() {
+    let model = cm("abc  def ghi   jkl|");
+    assert_eq!(tx(&model), "abc&nbsp;&nbsp;def ghi&nbsp;&nbsp;&nbsp;jkl|");
 }
 
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -14,7 +14,7 @@
 
 #![cfg(test)]
 
-use crate::tests::testutils_composer_model::{cm, tx};
+use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
 
 #[test]
 fn backspacing_a_character_at_the_end_deletes_it() {
@@ -110,7 +110,7 @@ fn deleting_across_list_items_joins_them() {
         </ol>");
     model.delete();
     assert_eq!(
-        tx(&model),
+        restore_whitespace(&tx(&model)),
         "<ol>
             <li>1|4</li>
         </ol>"
@@ -129,7 +129,7 @@ fn deleting_across_lists_joins_them() {
         </ol>");
     model.delete();
     assert_eq!(
-        tx(&model),
+        restore_whitespace(&tx(&model)),
         "<ol>
             <li>1|4</li>
         </ol>"
@@ -151,7 +151,7 @@ fn deleting_across_lists_joins_them_nested() {
         </ol>");
     model.delete();
     assert_eq!(
-        tx(&model),
+        restore_whitespace(&tx(&model)),
         "<ol>
             <li>1|4</li>
         </ol>"
@@ -162,14 +162,14 @@ fn deleting_across_lists_joins_them_nested() {
 fn deleting_across_formatting_different_types() {
     let mut model = cm("<b><i>some {italic</i></b> and}| <b>bold</b> text");
     model.delete();
-    assert_eq!(tx(&model), "<b><i>some |</i></b> <b>bold</b> text");
+    assert_eq!(tx(&model), "<b><i>some&nbsp;|</i></b> <b>bold</b> text");
 }
 
 #[test]
 fn deleting_across_formatting_different_types_on_node_boundary() {
     let mut model = cm("<b><i>some {italic</i></b> and }|<b>bold</b> text");
     model.delete();
-    assert_eq!(tx(&model), "<b><i>some |</i>bold</b> text");
+    assert_eq!(tx(&model), "<b><i>some&nbsp;|</i>bold</b> text");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -50,7 +50,7 @@ fn format_several_nodes_with_empty_text_nodes() {
     model.italic();
     model.select(Location::from(2), Location::from(17));
     model.strike_through();
-    assert_eq!(tx(&model), "<strong>so<del>{me</del></strong><del> </del><em><del>different</del></em><del> no}|</del>des")
+    assert_eq!(tx(&model), "<strong>so<del>{me</del></strong><del>&nbsp;</del><em><del>different</del></em><del> no}|</del>des")
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/testutils_composer_model.rs
+++ b/crates/wysiwyg/src/tests/testutils_composer_model.rs
@@ -16,7 +16,7 @@
 
 use widestring::Utf16String;
 
-use crate::ComposerModel;
+use crate::{ComposerModel, UnicodeString};
 
 /// Short wrapper around [ComposerModel::from_example_format].
 pub fn cm(text: &str) -> ComposerModel<Utf16String> {
@@ -26,4 +26,12 @@ pub fn cm(text: &str) -> ComposerModel<Utf16String> {
 /// Short wrapper around [ComposerModel::to_example_format].
 pub fn tx(model: &ComposerModel<Utf16String>) -> String {
     model.to_example_format()
+}
+
+pub(crate) fn restore_whitespace(text: &String) -> String {
+    text.replace("&nbsp;", " ").replace("\u{A0}", " ")
+}
+
+pub(crate) fn restore_whitespace_u16(text: &Utf16String) -> Utf16String {
+    Utf16String::from(restore_whitespace(&text.to_utf8()))
 }

--- a/platforms/android/.idea/androidTestResultsUserPreferences.xml
+++ b/platforms/android/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1844953769">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-974135907">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="28629151">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
@@ -245,6 +245,7 @@ class InterceptInputConnection(
             if (result != null) {
                 replaceAll(result.text, 0, editable.length, 1)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
+                setComposingRegion(result.selection.first, result.selection.last)
             }
             // TODO: handle result == null
             handled = true
@@ -258,6 +259,7 @@ class InterceptInputConnection(
             if (result != null) {
                 replaceAll(result.text, 0, editable.length, 1)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
+                setComposingRegion(result.selection.first, result.selection.last)
             }
             // TODO: handle result == null
             handled = true


### PR DESCRIPTION
* Added `&nbsp;` support to our the HTML output.
* Re-wrote the way that selection is written to the output in `to_example_format`.
* Added some extra helper method for tests `restore_whitespace` and `restore_whitespace_u16` so those `&nbsp;` are translated back to simple whitespaces and the strings containing can be used in assertions with no issues.