### PR TITLE
[iOS] Enable Swiftlint & SwiftFormat from the example app

### DIFF
--- a/platforms/ios/example/.swiftformat
+++ b/platforms/ios/example/.swiftformat
@@ -1,0 +1,12 @@
+--swiftversion 5.6
+
+--disable wrapMultiLineStatementBraces
+--disable hoistPatternLet
+
+--ifdef no-indent
+--nospaceoperators ...,..<
+--stripunusedargs closure-only
+--trimwhitespace nonblank-lines
+--wrapparameters after-first
+--redundanttype inferred
+--emptybraces spaced

--- a/platforms/ios/example/.swiftlint.yml
+++ b/platforms/ios/example/.swiftlint.yml
@@ -13,10 +13,6 @@ opt_in_rules:
   - private_action
   - explicit_init
 
-# paths to ignore during linting. Takes precedence over `included`.
-excluded:
-  - Sources/WysiwygComposer/WysiwygComposer.swift
-
 line_length:
   warning: 140
   error: 200

--- a/platforms/ios/example/Brewfile
+++ b/platforms/ios/example/Brewfile
@@ -1,0 +1,2 @@
+brew "swiftformat"
+brew "swiftlint"

--- a/platforms/ios/example/Brewfile.lock.json
+++ b/platforms/ios/example/Brewfile.lock.json
@@ -1,0 +1,81 @@
+{
+  "entries": {
+    "brew": {
+      "swiftformat": {
+        "version": "0.49.18",
+        "bottle": {
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "files": {
+            "arm64_monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:6362f6087bc3821f4271c3d17b3a4f180b1e1326646ddfb60f6d27bfb5a2a357",
+              "sha256": "6362f6087bc3821f4271c3d17b3a4f180b1e1326646ddfb60f6d27bfb5a2a357"
+            },
+            "arm64_big_sur": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:e94cf1b66df0d712bbfbf509b98efaf31d39a61b82999314e1f3c0e45195c51a",
+              "sha256": "e94cf1b66df0d712bbfbf509b98efaf31d39a61b82999314e1f3c0e45195c51a"
+            },
+            "monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:456e0c95a565adbb45a29747abfadf41c838a7f09fae052a874e59429a94ef14",
+              "sha256": "456e0c95a565adbb45a29747abfadf41c838a7f09fae052a874e59429a94ef14"
+            },
+            "big_sur": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:d00204be714789fa8b35d4c6f6eea5813604aa09f3911635059973aa827d2e8c",
+              "sha256": "d00204be714789fa8b35d4c6f6eea5813604aa09f3911635059973aa827d2e8c"
+            },
+            "catalina": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:b07f7221f3c5225ad0037293cecb95bde4f0dba4fa19797d84a3376dd1ad02ea",
+              "sha256": "b07f7221f3c5225ad0037293cecb95bde4f0dba4fa19797d84a3376dd1ad02ea"
+            },
+            "x86_64_linux": {
+              "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:c4a4ebd2f3f54b8f399551efaf47b3e419db2c729ffaf18a09e64bbf62d82f38",
+              "sha256": "c4a4ebd2f3f54b8f399551efaf47b3e419db2c729ffaf18a09e64bbf62d82f38"
+            }
+          }
+        }
+      },
+      "swiftlint": {
+        "version": "0.49.1",
+        "bottle": {
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "files": {
+            "arm64_monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:d983879e2d9ea075bf80e223da5adb258f01d9fab4fc6f71f83c4add80490290",
+              "sha256": "d983879e2d9ea075bf80e223da5adb258f01d9fab4fc6f71f83c4add80490290"
+            },
+            "monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:73a9664d8a62c7b5d506a70bf100e0289795df04ece6df12f0b77651e497d42b",
+              "sha256": "73a9664d8a62c7b5d506a70bf100e0289795df04ece6df12f0b77651e497d42b"
+            },
+            "x86_64_linux": {
+              "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:705904346a73422be8f053d7b1c413e5d18623bd7244cb33d188d921a072e600",
+              "sha256": "705904346a73422be8f053d7b1c413e5d18623bd7244cb33d188d921a072e600"
+            }
+          }
+        }
+      }
+    }
+  },
+  "system": {
+    "macos": {
+      "monterey": {
+        "HOMEBREW_VERSION": "3.6.2",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "4d9c5d1480ebc5401d3d0ffa698660c484abf33b",
+        "CLT": "13.4.0.0.1.1651278267",
+        "Xcode": "13.4.1",
+        "macOS": "12.4"
+      }
+    }
+  }
+}

--- a/platforms/ios/example/README.md
+++ b/platforms/ios/example/README.md
@@ -10,6 +10,12 @@ All that is required is to run `make ios` in the repository main folder
 in order to build uniffi bindings for Swift, then the app will build
 directly from XCode.
 
+# Enable SwiftLint & SwiftFormat
+
+SwiftLint and SwiftFormat can be enabled on both the library and the
+example application from this project. The only requirement is to run `brew bundle` inside this folder, then both tools will run anytime the
+example app is built.
+
 # Gather global code coverage for WysiwygComposer.
 
 The main scheme `Wysiwyg` provides an associated test suite that run both

--- a/platforms/ios/example/Shared/View+Accessibility.swift
+++ b/platforms/ios/example/Shared/View+Accessibility.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,24 +34,25 @@ public enum WysiwygSharedAccessibilityIdentifier: String {
     case htmlContentText = "WysiwygHtmlContentText"
 }
 
-extension View {
+public extension View {
     /// Sets up an accessibility identifier to the view from the enum
     /// of expected accessibilityIdentifiers.
     ///
     /// - Parameters:
     ///   - identifier: the accessibility identifier to setup
     /// - Returns: modified view
-    public func accessibilityIdentifier(_ identifier: WysiwygSharedAccessibilityIdentifier) -> ModifiedContent<Self, AccessibilityAttachmentModifier> {
-        return accessibilityIdentifier(identifier.rawValue)
+    func accessibilityIdentifier(_ identifier: WysiwygSharedAccessibilityIdentifier)
+        -> ModifiedContent<Self, AccessibilityAttachmentModifier> {
+        accessibilityIdentifier(identifier.rawValue)
     }
 }
 
-extension UIView {
+public extension UIView {
     /// Sets up an accessibility identifier to the view from the enum
     /// of expected accessibilityIdentifiers.
     ///
     /// - Parameter identifier: the accessibility identifer to setup
-    public func setAccessibilityIdentifier(_ identifier: WysiwygSharedAccessibilityIdentifier) {
-        self.accessibilityIdentifier = identifier.rawValue
+    func setAccessibilityIdentifier(_ identifier: WysiwygSharedAccessibilityIdentifier) {
+        accessibilityIdentifier = identifier.rawValue
     }
 }

--- a/platforms/ios/example/Shared/WysiwygAction+Utils.swift
+++ b/platforms/ios/example/Shared/WysiwygAction+Utils.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +14,13 @@
 // limitations under the License.
 //
 
-import WysiwygComposer
 import SwiftUI
+import WysiwygComposer
 
 extension WysiwygAction: CaseIterable, Identifiable {
     public static var allCases: [WysiwygAction] = [
         .bold, .italic, .strikeThrough, .underline, .inlineCode,
-        .link(url: "unset"), .undo, .redo, .orderedList, .unorderedList
+        .link(url: "unset"), .undo, .redo, .orderedList, .unorderedList,
     ]
 
     public var id: String {
@@ -32,9 +32,9 @@ extension WysiwygAction: CaseIterable, Identifiable {
     /// - Parameter viewModel: Composer's view model.
     /// - Returns: Tint color that the button should use.
     public func color(_ viewModel: WysiwygComposerViewModel) -> Color {
-        let isDisabled = self.isDisabled(viewModel)
+        let isDisabled = isDisabled(viewModel)
         // Buttons for reversed actions should be highlighted with a specific colour.
-        let isActive = viewModel.reversedActions.contains(self.composerAction)
+        let isActive = viewModel.reversedActions.contains(composerAction)
         switch (isDisabled, isActive) {
         case (true, _):
             return .black.opacity(0.3)
@@ -50,7 +50,7 @@ extension WysiwygAction: CaseIterable, Identifiable {
     /// - Parameter viewModel: Composer's view model.
     /// - Returns: True if the action is disabled, false otherwise.
     public func isDisabled(_ viewModel: WysiwygComposerViewModel) -> Bool {
-        return viewModel.disabledActions.contains(self.composerAction)
+        viewModel.disabledActions.contains(composerAction)
     }
 
     var accessibilityIdentifier: WysiwygSharedAccessibilityIdentifier {
@@ -108,7 +108,7 @@ extension WysiwygAction: CaseIterable, Identifiable {
 extension WysiwygAction: Equatable {
     public static func == (lhs: WysiwygAction, rhs: WysiwygAction) -> Bool {
         switch (lhs, rhs) {
-        case (.link(url: let lhsUrl), (.link(url: let rhsUrl))):
+        case let (.link(url: lhsUrl), .link(url: rhsUrl)):
             return lhsUrl == rhsUrl
         default:
             return lhs.id == rhs.id

--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
@@ -241,6 +241,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A6472CCB2886CF840021A0E8 /* Build configuration list for PBXNativeTarget "Wysiwyg" */;
 			buildPhases = (
+				A6F3FC0828DCAF8400C170E8 /* 🧹 SwiftFormat */,
+				A6F3FC0728DCADB300C170E8 /* ⚠️ SwiftLint */,
 				A6472CA32886CF830021A0E8 /* Sources */,
 				A6472CA42886CF830021A0E8 /* Frameworks */,
 				A6472CA52886CF830021A0E8 /* Resources */,
@@ -348,6 +350,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A6F3FC0728DCADB300C170E8 /* ⚠️ SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "⚠️ SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n    swiftlint $PROJECT_DIR\n    swiftlint ../lib/WysiwygComposer --config \"../lib/WysiwygComposer/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+		};
+		A6F3FC0828DCAF8400C170E8 /* 🧹 SwiftFormat */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "🧹 SwiftFormat";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n    swiftformat $PROJECT_DIR\n    swiftformat ../lib/WysiwygComposer\nelse\n    echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A643691A2899175400ECCF8A /* Sources */ = {

--- a/platforms/ios/example/Wysiwyg/Extensions/UIAlertController.swift
+++ b/platforms/ios/example/Wysiwyg/Extensions/UIAlertController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ extension UIAlertController {
         addAction(UIAlertAction(title: alert.cancel, style: .cancel) { _ in
             alert.action(nil)
         })
-        let textField = self.textFields?.first
+        let textField = textFields?.first
         addAction(UIAlertAction(title: alert.accept, style: .default) { _ in
             alert.action(textField?.text)
         })

--- a/platforms/ios/example/Wysiwyg/Extensions/View.swift
+++ b/platforms/ios/example/Wysiwyg/Extensions/View.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +16,8 @@
 
 import SwiftUI
 
-extension View {
-    public func alert(isPresented: Binding<Bool>, _ alert: AlertConfig) -> some View {
+public extension View {
+    func alert(isPresented: Binding<Bool>, _ alert: AlertConfig) -> some View {
         AlertHelper(isPresented: isPresented, alert: alert, content: self)
     }
 }

--- a/platforms/ios/example/Wysiwyg/Views/AlertHelper.swift
+++ b/platforms/ios/example/Wysiwyg/Views/AlertHelper.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,33 +22,35 @@ struct AlertHelper<Content: View>: UIViewControllerRepresentable {
     let alert: AlertConfig
     let content: Content
 
-    func makeUIViewController(context: UIViewControllerRepresentableContext<AlertHelper>) -> UIHostingController<Content> {
+    func makeUIViewController(context _: UIViewControllerRepresentableContext<AlertHelper>) -> UIHostingController<Content> {
         UIHostingController(rootView: content)
     }
 
     final class Coordinator {
         var alertController: UIAlertController?
         init(_ controller: UIAlertController? = nil) {
-            self.alertController = controller
+            alertController = controller
         }
     }
 
     func makeCoordinator() -> Coordinator {
-        return Coordinator()
+        Coordinator()
     }
 
-    func updateUIViewController(_ uiViewController: UIHostingController<Content>, context: UIViewControllerRepresentableContext<AlertHelper>) {
+    func updateUIViewController(_ uiViewController: UIHostingController<Content>,
+                                context: UIViewControllerRepresentableContext<AlertHelper>) {
         uiViewController.rootView = content
-        if isPresented && uiViewController.presentedViewController == nil {
-            var alert = self.alert
+        if isPresented, uiViewController.presentedViewController == nil {
+            var alert = alert
             alert.action = {
                 self.isPresented = false
                 self.alert.action($0)
             }
             context.coordinator.alertController = UIAlertController(alert: alert)
-            uiViewController.present(context.coordinator.alertController!, animated: true)
+            guard let controller = context.coordinator.alertController else { return }
+            uiViewController.present(controller, animated: true)
         }
-        if !isPresented && uiViewController.presentedViewController == context.coordinator.alertController {
+        if !isPresented, uiViewController.presentedViewController == context.coordinator.alertController {
             uiViewController.dismiss(animated: true)
         }
     }
@@ -56,7 +58,7 @@ struct AlertHelper<Content: View>: UIViewControllerRepresentable {
 
 public struct AlertConfig {
     public var title: String
-    public var accept: String = "OK"
-    public var cancel: String = "Cancel"
-    public var action: (String?) -> ()
+    public var accept = "OK"
+    public var cancel = "Cancel"
+    public var action: (String?) -> Void
 }

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ import WysiwygComposer
 
 struct WysiwygActionToolbar: View {
     @EnvironmentObject private var viewModel: WysiwygComposerViewModel
-    var toolbarAction: (WysiwygAction) -> ()
+    var toolbarAction: (WysiwygAction) -> Void
     @State private var isShowingUrlAlert = false
     @State private var linkAttributedRange = NSRange.zero
 
@@ -42,7 +42,6 @@ struct WysiwygActionToolbar: View {
                 .buttonStyle(.automatic)
                 .accessibilityIdentifier(action.accessibilityIdentifier)
             }
-
         }
         .alert(isPresented: $isShowingUrlAlert, AlertConfig(title: "Enter URL", action: { url in
             guard let url = url else { return }

--- a/platforms/ios/example/WysiwygUIKit/AppDelegate.swift
+++ b/platforms/ios/example/WysiwygUIKit/AppDelegate.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,28 +18,25 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        return true
+        true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options _: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    func application(_: UIApplication, didDiscardSceneSessions _: Set<UISceneSession>) {
         // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // If any sessions were discarded while the application was not running,
+        // this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/platforms/ios/example/WysiwygUIKit/SceneDelegate.swift
+++ b/platforms/ios/example/WysiwygUIKit/SceneDelegate.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,45 +17,41 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        // This delegate does not imply the connecting scene or session are new
+        // (see `application:configurationForConnectingSceneSession` instead).
+        guard scene as? UIWindowScene != nil else { return }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
+    func sceneDidDisconnect(_: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
-    func sceneDidBecomeActive(_ scene: UIScene) {
+    func sceneDidBecomeActive(_: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
 
-    func sceneWillResignActive(_ scene: UIScene) {
+    func sceneWillResignActive(_: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
-    func sceneWillEnterForeground(_ scene: UIScene) {
+    func sceneWillEnterForeground(_: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
 
-    func sceneDidEnterBackground(_ scene: UIScene) {
+    func sceneDidEnterBackground(_: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/platforms/ios/example/WysiwygUIKit/ViewController.swift
+++ b/platforms/ios/example/WysiwygUIKit/ViewController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,12 +24,12 @@ private enum Constants {
 /// Example UIKit view that adds a WysiwygComposer as well as a button that
 /// displays the message (+ HTML representation) the composer would send.
 final class ViewController: UIViewController {
-    @IBOutlet private weak var wysiwygHostingView: WysiwygHostingView!
-    @IBOutlet private weak var wysiwygActionsStackView: UIStackView!
-    @IBOutlet private weak var sendButton: UIButton!
-    @IBOutlet private weak var contentLabel: UILabel!
-    @IBOutlet private weak var htmlContentLabel: UILabel!
-    @IBOutlet private weak var wysiwygHostingViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet private var wysiwygHostingView: WysiwygHostingView!
+    @IBOutlet private var wysiwygActionsStackView: UIStackView!
+    @IBOutlet private var sendButton: UIButton!
+    @IBOutlet private var contentLabel: UILabel!
+    @IBOutlet private var htmlContentLabel: UILabel!
+    @IBOutlet private var wysiwygHostingViewHeightConstraint: NSLayoutConstraint!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -56,7 +56,7 @@ private extension ViewController {
         wysiwygHostingView.apply(action)
     }
 
-    @IBAction func sendButtonTouchedUpInside(_ sender: UIButton) {
+    @IBAction func sendButtonTouchedUpInside(_: UIButton) {
         // Get the current content of the composer.
         contentLabel.text = wysiwygHostingView.content.plainText
         htmlContentLabel.text = wysiwygHostingView.content.html
@@ -81,8 +81,8 @@ private final class WysiwygActionButton: UIButton {
 
     func setAction(_ wysiwygAction: WysiwygAction) {
         self.wysiwygAction = wysiwygAction
-        self.accessibilityIdentifier = wysiwygAction.accessibilityIdentifier.rawValue
-        self.setImage(UIImage(systemName: wysiwygAction.iconName),
-                      for: .normal)
+        accessibilityIdentifier = wysiwygAction.accessibilityIdentifier.rawValue
+        setImage(UIImage(systemName: wysiwygAction.iconName),
+                 for: .normal)
     }
 }

--- a/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 /// Defines tests that can be shared between the SwiftUI and the UIKit example implementations.
 final class WysiwygSharedTests {
@@ -55,7 +55,7 @@ final class WysiwygSharedTests {
         // Double tap results in selecting the last word.
         textView.doubleTap()
         deleteKey.tap()
-        XCTAssertEqual(textView.value as? String, "abcde 🥳 ")
+        XCTAssertEqual(textView.value as? String, "abcde 🥳 ")
 
         // Triple tap selects the entire line.
         textView.tap(withNumberOfTaps: 3, numberOfTouches: 1)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUIKitTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUIKitTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ class WysiwygUIKitTests: XCTestCase {
 
     func testTypingAndBolding() throws {
         let attachment = try WysiwygSharedTests.testTypingAndBolding(app)
-        self.add(attachment)
+        add(attachment)
     }
 
     func testTypingAndSending() throws {

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -33,7 +33,7 @@ class WysiwygUITests: XCTestCase {
 
     func testTypingAndBolding() throws {
         let attachment = try WysiwygSharedTests.testTypingAndBolding(app)
-        self.add(attachment)
+        add(attachment)
     }
 
     func testTypingAndSending() throws {

--- a/platforms/ios/lib/WysiwygComposer/.swiftformat
+++ b/platforms/ios/lib/WysiwygComposer/.swiftformat
@@ -1,0 +1,12 @@
+--swiftversion 5.6
+
+--disable wrapMultiLineStatementBraces
+--disable hoistPatternLet
+
+--ifdef no-indent
+--nospaceoperators ...,..<
+--stripunusedargs closure-only
+--trimwhitespace nonblank-lines
+--wrapparameters after-first
+--redundanttype inferred
+--emptybraces spaced

--- a/platforms/ios/lib/WysiwygComposer/Package.swift
+++ b/platforms/ios/lib/WysiwygComposer/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         ),
         .testTarget(
             name: "WysiwygComposerTests",
-            dependencies: ["WysiwygComposer"]),
+            dependencies: ["WysiwygComposer"]
+        ),
     ]
 )

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygAction.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygAction.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ import Foundation
 /// Defines message content displayed in the composer.
 public class WysiwygComposerContent: NSObject {
     // MARK: - Public
+
     /// Displayed text, as plain text.
     public let plainText: String
     /// HTML representation of the displayed text.
@@ -30,6 +31,7 @@ public class WysiwygComposerContent: NSObject {
     public var attributedSelection: NSRange
 
     // MARK: - Internal
+
     /// Init.
     ///
     /// - Parameters:

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -14,12 +14,13 @@
 // limitations under the License.
 //
 
-import SwiftUI
 import OSLog
+import SwiftUI
 
 /// Provides a SwiftUI displayable view for the composer UITextView component.
 struct WysiwygComposerView: UIViewRepresentable {
     // MARK: - Internal
+
     var content: WysiwygComposerContent
     var replaceText: (NSAttributedString, NSRange, String) -> Bool
     var select: (NSAttributedString, NSRange) -> Void
@@ -42,7 +43,7 @@ struct WysiwygComposerView: UIViewRepresentable {
         Logger.textView.logDebug([content.logAttributedSelection,
                                   content.logText],
                                  functionName: #function)
-        uiView.apply(self.content)
+        uiView.apply(content)
         context.coordinator.didUpdateText(uiView)
     }
 
@@ -69,25 +70,26 @@ struct WysiwygComposerView: UIViewRepresentable {
                                       textView.logText,
                                       "Replacement: \"\(text)\""],
                                      functionName: #function)
-            return self.replaceText(textView.attributedText, range, text)
+            return replaceText(textView.attributedText, range, text)
         }
 
         func textViewDidChange(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection,
                                       textView.logText],
                                      functionName: #function)
-            self.didUpdateText(textView)
+            didUpdateText(textView)
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
                                      functionName: #function)
-            self.select(textView.attributedText, textView.selectedRange)
+            select(textView.attributedText, textView.selectedRange)
         }
     }
 }
 
 // MARK: - Logger
+
 private extension Logger {
     static let textView = Logger(subsystem: subsystem, category: "TextView")
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygHostingView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygHostingView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +14,10 @@
 // limitations under the License.
 //
 
-import UIKit
-import SwiftUI
 import Combine
 import OSLog
+import SwiftUI
+import UIKit
 
 /// Declares methods that should be adopted by an object that aim to react on the Wysiwyg composer actions.
 @objc public protocol WysiwygHostingViewDelegate: AnyObject {
@@ -37,18 +37,21 @@ import OSLog
 @objcMembers
 public final class WysiwygHostingView: UIView {
     // MARK: - Public
+
     /// The delegate of the `WysiwygHostingView`.
     public weak var delegate: WysiwygHostingViewDelegate?
     /// The content currently displayed in the composer.
     public var content: WysiwygComposerContent {
-        return viewModel.content
+        viewModel.content
     }
 
     // MARK: - Private
+
     @ObservedObject private var viewModel = WysiwygComposerViewModel()
     private var cancellables: Set<AnyCancellable>?
 
     // MARK: - Public
+
     /// Apply given action to the composer.
     ///
     /// - Parameters:
@@ -63,7 +66,8 @@ public final class WysiwygHostingView: UIView {
     }
 
     // MARK: - Override
-    public override func awakeFromNib() {
+
+    override public func awakeFromNib() {
         super.awakeFromNib()
 
         let wysiwygView = WysiwygView()

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygView.swift
@@ -14,29 +14,31 @@
 // limitations under the License.
 //
 
-import SwiftUI
 import OSLog
+import SwiftUI
 
 /// Composer's main view. Displays a text view and a toolbar for advanced edition capabilities.
 public struct WysiwygView: View {
     // MARK: - Public
+
     public var body: some View {
         VStack {
             WysiwygComposerView(content: viewModel.content,
                                 replaceText: viewModel.replaceText,
                                 select: viewModel.select,
                                 didUpdateText: viewModel.didUpdateText)
-            .padding(.all, 8)
-            .padding([.leading, .trailing], 8)
-            .padding([.top, .bottom], 4)
-            .onAppear {
-                viewModel.setup()
-            }
+                .padding(.all, 8)
+                .padding([.leading, .trailing], 8)
+                .padding([.top, .bottom], 4)
+                .onAppear {
+                    viewModel.setup()
+                }
         }
     }
 
     public init() { }
 
     // MARK: - Private
+
     @EnvironmentObject private var viewModel: WysiwygComposerViewModel
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
@@ -18,8 +18,10 @@ import OSLog
 import UIKit
 
 // MARK: - Logger
+
 extension Logger {
     // MARK: Internal
+
     static var subsystem = "org.matrix.WysiwygComposer"
 
     /// Creates a customized log for debug.
@@ -28,7 +30,7 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logDebug(_ elements: [String], functionName: String) {
-        self.debug("\(customLog(elements, functionName: functionName))")
+        debug("\(customLog(elements, functionName: functionName))")
     }
 
     /// Creates a customized error log.
@@ -37,7 +39,7 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logError(_ elements: [String], functionName: String) {
-        self.error("\(customLog(elements, functionName: functionName))")
+        error("\(customLog(elements, functionName: functionName))")
     }
 
     /// Creates a customized warning log.
@@ -46,10 +48,11 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logWarning(_ elements: [String], functionName: String) {
-        self.warning("\(customLog(elements, functionName: functionName))")
+        warning("\(customLog(elements, functionName: functionName))")
     }
 
     // MARK: Private
+
     private func customLog(_ elements: [String], functionName: String) -> String {
         var logMessage = elements.map { $0 + " | " }.joined()
         logMessage.append(contentsOf: functionName)
@@ -58,27 +61,29 @@ extension Logger {
 }
 
 // MARK: - UITextView + Logger
+
 extension UITextView {
     /// Returns a log ready description of the current selection.
     var logSelection: String {
-        return "Sel(att): \(self.selectedRange)"
+        "Sel(att): \(selectedRange)"
     }
 
     /// Returns a log ready description of the current text..
     var logText: String {
-        return "Text: \"\(self.text ?? "")\""
+        "Text: \"\(text ?? "")\""
     }
 }
 
 // MARK: - WysiwygComposerContent + Logger
+
 extension WysiwygComposerContent {
     /// Returns a log ready description of the attributed selection.
     var logAttributedSelection: String {
-        return "Sel(att): \(self.attributedSelection)"
+        "Sel(att): \(attributedSelection)"
     }
 
     /// Returns a log ready description of the text.
     var logText: String {
-        return "Text: \"\(self.plainText)\""
+        "Text: \"\(plainText)\""
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -22,9 +22,9 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - index: the attributed string index to lookup
     /// - Returns: the character at given location
-    func character(at index: Int) -> Character {
-        let substring = self.attributedSubstring(from: .init(location: index, length: 1))
-        return substring.string.first!
+    func character(at index: Int) -> Character? {
+        let substring = attributedSubstring(from: .init(location: index, length: 1))
+        return substring.string.first
     }
 
     /// Enumerate attribute for given key and conveniently ignore any attribute that doesn't match given generic type.
@@ -38,9 +38,9 @@ extension NSAttributedString {
                                     in enumerationRange: NSRange? = nil,
                                     options opts: NSAttributedString.EnumerationOptions = [],
                                     using block: (T, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        self.enumerateAttribute(attrName,
-                                in: enumerationRange ?? .init(location: 0, length: length),
-                                options: opts) { (attr: Any?, range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) in
+        enumerateAttribute(attrName,
+                           in: enumerationRange ?? .init(location: 0, length: length),
+                           options: opts) { (attr: Any?, range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) in
             guard let typedAttr = attr as? T else { return }
 
             block(typedAttr, range, stop)
@@ -53,7 +53,7 @@ extension NSAttributedString {
     ///   - index: the attributed string index to lookup
     /// - Returns: the symbolic traits at givem location, empty if no font is defined
     func fontSymbolicTraits(at index: Int) -> UIFontDescriptor.SymbolicTraits {
-        let font = self.attribute(.font, at: index, effectiveRange: nil) as? UIFont
+        let font = attribute(.font, at: index, effectiveRange: nil) as? UIFont
         return font?.fontDescriptor.symbolicTraits ?? []
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+HTML.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+HTML.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ enum BuildHtmlAttributedError: LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
-        case .dataError(encoding: let encoding):
+        case let .dataError(encoding: encoding):
             return "Unable to encode string with: \(encoding.description) rawValue: \(encoding.rawValue)"
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSRange.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSRange.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 
 import Foundation
 
-extension NSRange {
+public extension NSRange {
     /// Returns a range at starting location, i.e. {0, 0}.
-    public static let zero = Self.init(location: 0, length: 0)
+    static let zero = Self(location: 0, length: 0)
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/String.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/String.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,6 @@ import Foundation
 extension String {
     /// Returns length of the string in UTF16 code units.
     var utf16Length: Int {
-        return (self as NSString).length
+        (self as NSString).length
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ extension UITextView {
     /// - Parameters:
     ///   - content: Content to apply.
     func apply(_ content: WysiwygComposerContent) {
-        self.performWithoutDelegate {
+        performWithoutDelegate {
             self.attributedText = content.attributed
             // Set selection to {0, 0} then to expected position
             // avoids an issue with autocapitalization.
@@ -41,9 +41,9 @@ private extension UITextView {
     /// - Parameters:
     ///   - block: Code block to perform.
     func performWithoutDelegate(block: () -> Void) {
-        let myDelegate = self.delegate
-        self.delegate = nil
+        let myDelegate = delegate
+        delegate = nil
         block()
-        self.delegate = myDelegate
+        delegate = myDelegate
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ import UIKit
 extension UIView {
     /// Add a subview matching parent view using autolayout
     func addSubViewMatchingParent(_ subView: UIView) {
-        self.addSubview(subView)
+        addSubview(subView)
         subView.translatesAutoresizingMaskIntoConstraints = false
         let views = ["view": subView]
         ["H:|[view]|", "V:|[view]|"].forEach { vfl in

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,9 @@
 // limitations under the License.
 //
 
-import XCTest
 import Combine
 @testable import WysiwygComposer
+import XCTest
 
 final class WysiwygComposerViewModelTests: XCTestCase {
     private let viewModel = WysiwygComposerViewModel()
@@ -28,9 +28,9 @@ final class WysiwygComposerViewModelTests: XCTestCase {
     func testIsContentEmpty() throws {
         XCTAssertTrue(viewModel.isContentEmpty)
 
-        let expectFalse = self.expectation(description: "Await isContentEmpty false")
+        let expectFalse = expectation(description: "Await isContentEmpty false")
         let cancellableFalse = viewModel.$isContentEmpty
-        // Ignore on subscribe publish.
+            // Ignore on subscribe publish.
             .dropFirst()
             .removeDuplicates()
             .sink(receiveValue: { isEmpty in
@@ -45,9 +45,9 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         wait(for: [expectFalse], timeout: 2.0)
         cancellableFalse.cancel()
 
-        let expectTrue = self.expectation(description: "Await isContentEmpty true")
+        let expectTrue = expectation(description: "Await isContentEmpty true")
         let cancellableTrue = viewModel.$isContentEmpty
-        // Ignore on subscribe publish.
+            // Ignore on subscribe publish.
             .dropFirst()
             .removeDuplicates()
             .sink(receiveValue: { isEmpty in

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringAttributesTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringAttributesTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 final class NSAttributedStringTests: XCTestCase {
     func testEnumerateTypedAttribute() {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringHTMLTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringHTMLTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 final class NSAttributedStringHtmlTests: XCTestCase {
     func testBuildAttributedFromHtml() throws {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/NSAttributedStringRangeTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 final class NSAttributedStringRangeTests: XCTestCase {
     func testAttributedNumberedLists() throws {
@@ -27,8 +27,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
         // Ranges that are not part of the raw HTML text (excluding tags) are detected
         XCTAssertEqual(attributed.listPrefixesRanges(),
                        [NSRange(location: 0, length: 4),
-                        NSRange(location: 10, length: 5),
-                       ])
+                        NSRange(location: 10, length: 5)])
         // Converting back and forth from HTML to attributed postions
         XCTAssertEqual(try attributed.attributedPosition(at: 0), 4)
         XCTAssertEqual(try attributed.attributedPosition(at: 7), 16)
@@ -70,8 +69,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
                        "\t•\tItem 1\n\t•\tItem 2\nSome Text")
         XCTAssertEqual(attributed.listPrefixesRanges(),
                        [NSRange(location: 0, length: 3),
-                        NSRange(location: 9, length: 4),
-                       ])
+                        NSRange(location: 9, length: 4)])
         XCTAssertEqual(try attributed.attributedPosition(at: 0), 3)
         XCTAssertEqual(try attributed.attributedPosition(at: 7), 14)
         XCTAssertEqual(try attributed.htmlPosition(at: 14), 7)
@@ -87,8 +85,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
                        [NSRange(location: 0, length: 4),
                         NSRange(location: 10, length: 5),
                         NSRange(location: 21, length: 4),
-                        NSRange(location: 31, length: 4),
-                       ])
+                        NSRange(location: 31, length: 4)])
         XCTAssertEqual(try attributed.attributedPosition(at: 14), 27)
         XCTAssertEqual(try attributed.htmlPosition(at: 27), 14)
         XCTAssertEqual(try attributed.attributedRange(from: .init(location: 0, length: 12)),

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/TestConstants.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/TestConstants.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/UITextViewTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/UITextViewTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,8 @@
 //
 
 import UIKit
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 final class UITextViewTests: XCTestCase {
     func testTextViewUTF16Encoding() throws {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import XCTest
 @testable import WysiwygComposer
+import XCTest
 
 // FIXME: replace ZWSP with another solution
 private enum Constants {
@@ -29,9 +29,9 @@ final class WysiwygComposerTests: XCTestCase {
         switch update.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             // Text is preserved, including emojis.
             XCTAssertEqual(String(utf16CodeUnits: codeUnits, count: codeUnits.count),
                            TestConstants.testStringWithEmojis)
@@ -51,9 +51,9 @@ final class WysiwygComposerTests: XCTestCase {
         switch update.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             // Text should remove exactly the last emoji.
             XCTAssertEqual(String(utf16CodeUnits: codeUnits, count: codeUnits.count),
                            TestConstants.testStringAfterBackspace)
@@ -70,9 +70,9 @@ final class WysiwygComposerTests: XCTestCase {
         switch update.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
             XCTAssertEqual(html,
                            "This is <strong>bold</strong> text")
@@ -113,16 +113,16 @@ final class WysiwygComposerTests: XCTestCase {
         switch update.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
             XCTAssertEqual(html,
                            "<ol><li>Item 1</li><li>"
-                           + Constants.zwsp
-                           + "Item 2</li><li>"
-                           + Constants.zwsp
-                           + "</li></ol>")
+                               + Constants.zwsp
+                               + "Item 2</li><li>"
+                               + Constants.zwsp
+                               + "</li></ol>")
             XCTAssertEqual(start, end)
             XCTAssertEqual(start, 14)
         }
@@ -131,15 +131,15 @@ final class WysiwygComposerTests: XCTestCase {
         switch update2.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
             XCTAssertEqual(html,
                            "<ol><li>Item 1</li><li>"
-                           + Constants.zwsp
-                           + "Item 2</li></ol>"
-                           + Constants.zwsp)
+                               + Constants.zwsp
+                               + "Item 2</li></ol>"
+                               + Constants.zwsp)
             XCTAssertEqual(start, end)
             XCTAssertEqual(start, 14)
         }
@@ -148,16 +148,16 @@ final class WysiwygComposerTests: XCTestCase {
         switch update3.textUpdate() {
         case .keep, .select:
             XCTFail("Expected replace all HTML update")
-        case .replaceAll(replacementHtml: let codeUnits,
-                         startUtf16Codeunit: let start,
-                         endUtf16Codeunit: let end):
+        case let .replaceAll(replacementHtml: codeUnits,
+                             startUtf16Codeunit: start,
+                             endUtf16Codeunit: end):
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
             XCTAssertEqual(html,
                            "<ol><li>Item 1</li><li>"
-                           + Constants.zwsp
-                           + "Item 2</li></ol>"
-                           + Constants.zwsp
-                           + "Some text")
+                               + Constants.zwsp
+                               + "Item 2</li></ol>"
+                               + Constants.zwsp
+                               + "Some text")
             XCTAssertEqual(start, end)
             XCTAssertEqual(start, 23)
         }


### PR DESCRIPTION
Enables both tools to be run on any application build. (linting and formatting code for both the library and the app)
Added additional setup information in example app README. 