### PR TITLE
Add script to push ios library to the package repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@
 /bindings/wysiwyg-wasm/node_modules/
 /platforms/android/example/.idea/
 /platforms/android/out/
-
+/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/WysiwygComposer.swift
+/platforms/ios/lib/WysiwygComposer/WysiwygComposerFFI.xcframework
+/build/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ make
 To build for a single platform, or to learn more, see the individual README
 files above.
 
+## Release the code
+
+* Swift/iOS:
+Run `release_ios.sh` which will open a PR against [the swift package repo](https://github.com/matrix-org/matrix-wysiwyg-composer-swift) with the latest from main(in future will handle tags/releases).
+
 ## More info
 
 For more detailed explanations and examples of platform-specific code to use

--- a/platforms/ios/lib/WysiwygComposer/.gitignore
+++ b/platforms/ios/lib/WysiwygComposer/.gitignore
@@ -8,6 +8,3 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
-# Generated
-WysiwygComposerFFI.xcframework
-Sources/WysiwygComposer/WysiwygComposer.swift

--- a/release_ios.sh
+++ b/release_ios.sh
@@ -9,12 +9,12 @@ else
   exit 1
 fi
 
-# if [ -z "$(git status --porcelain)" ]; then 
-#   echo "Working directory is clean."
-# else 
-#   echo "Working directory is not clean. Exiting..."
-#   exit 1
-# fi
+if [ -z "$(git status --porcelain)" ]; then 
+  echo "Working directory is clean."
+else 
+  echo "Working directory is not clean. Exiting..."
+  exit 1
+fi
 
 # Complete any prerequisates as defined in /bindings/wysiwyg-ffi/README.md#ios
 make ios

--- a/release_ios.sh
+++ b/release_ios.sh
@@ -16,7 +16,7 @@ else
   exit 1
 fi
 
-# Complete any prerequisates as defined in /bindings/wysiwyg-ffi/README.md#ios
+# Complete any prerequisites as defined in /bindings/wysiwyg-ffi/README.md#ios
 make ios
 
 BUILD_DIR=build

--- a/release_ios.sh
+++ b/release_ios.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+if [ $BRANCH_NAME == "main" ]; then 
+  echo "On main branch."
+else 
+  echo "Not on main branch. Exiting..."
+  exit 1
+fi
+
+# if [ -z "$(git status --porcelain)" ]; then 
+#   echo "Working directory is clean."
+# else 
+#   echo "Working directory is not clean. Exiting..."
+#   exit 1
+# fi
+
+# Complete any prerequisates as defined in /bindings/wysiwyg-ffi/README.md#ios
+make ios
+
+BUILD_DIR=build
+REPO_PATH="${BUILD_DIR}/matrix-wysiwyg"
+WYSIWYG_COMPOSER_PATH="platforms/ios/lib/WysiwygComposer/"
+rm -rf $BUILD_DIR
+mkdir $BUILD_DIR
+git clone git@github.com:matrix-org/matrix-wysiwyg-composer-swift.git $REPO_PATH
+git checkout main
+cp -R $WYSIWYG_COMPOSER_PATH $REPO_PATH
+last_commit=$(git rev-parse --short HEAD);
+RELEASE_BRANCH="release_$last_commit"
+cd $REPO_PATH
+git checkout -b $RELEASE_BRANCH
+git add .
+git commit -m "release $last_commit"
+git push origin $RELEASE_BRANCH


### PR DESCRIPTION
- Adds a script that opens a PR against the package repo with the latest iOS lib
- Creating a PR means we can test the changes against the PR branch before merging
- Can add versioning/tags/release int he future but not sure we need that yet