### PR TITLE
Refactor UnicodeString

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -217,7 +217,7 @@ impl TextUpdate {
                 Self {
                     keep: None,
                     replace_all: Some(ReplaceAll {
-                        replacement_html: r.replacement_html.to_utf8(),
+                        replacement_html: r.replacement_html.to_string(),
                         start_utf16_codeunit: u32::try_from(
                             start_utf16_codeunit,
                         )
@@ -370,7 +370,7 @@ impl DomHandle {
         match node {
             wysiwyg::DomNode::Container(_) => String::from(""),
             wysiwyg::DomNode::LineBreak(_) => String::from(""),
-            wysiwyg::DomNode::Text(node) => node.data().to_utf8(),
+            wysiwyg::DomNode::Text(node) => node.data().to_string(),
         }
     }
 
@@ -381,8 +381,8 @@ impl DomHandle {
     pub fn tag(&self, model: &ComposerModel) -> String {
         let node = model.inner.state.dom.lookup_node(&self.inner);
         match node {
-            wysiwyg::DomNode::Container(node) => node.name().to_utf8(),
-            wysiwyg::DomNode::LineBreak(node) => node.name().to_utf8(),
+            wysiwyg::DomNode::Container(node) => node.name().to_string(),
+            wysiwyg::DomNode::LineBreak(node) => node.name().to_string(),
             wysiwyg::DomNode::Text(_) => String::from("-text-"),
         }
     }

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -71,7 +71,7 @@ where
     /// This will remove all previous and next states, effectively disabling
     /// undo and redo until further updates.
     pub fn replace_all_html(&mut self, html: &S) -> ComposerUpdate<S> {
-        let dom = parse(&html.to_utf8());
+        let dom = parse(&html.to_string());
 
         match dom {
             Ok(dom) => {

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -135,7 +135,7 @@ pub(crate) fn slice<S>(s: &S, range: std::ops::Range<usize>) -> S
 where
     S: UnicodeString,
 {
-    S::from_vec(s.as_slice()[range].to_vec()).expect("Invalid slice!")
+    S::from_vec(s.as_ref()[range].to_vec()).expect("Invalid slice!")
 }
 
 pub(crate) fn starts_with(subject: &DomHandle, object: &DomHandle) -> bool {

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -14,6 +14,7 @@
 
 use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, UnicodeString};
 use crate::{ComposerAction, ComposerUpdate, Location, ToHtml, ToTree};
 use std::collections::HashSet;

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -14,7 +14,6 @@
 
 use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
-use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, UnicodeString};
 use crate::{ComposerAction, ComposerUpdate, Location, ToHtml, ToTree};
 use std::collections::HashSet;
@@ -114,29 +113,6 @@ where
     pub fn to_tree(&self) -> S {
         self.state.dom.to_tree()
     }
-}
-
-pub(crate) fn slice_to<S>(s: &S, range: std::ops::RangeTo<usize>) -> S
-where
-    S: UnicodeString,
-{
-    slice(s, 0..range.end)
-}
-
-pub(crate) fn slice_from<S>(s: &S, range: std::ops::RangeFrom<usize>) -> S
-where
-    S: UnicodeString,
-{
-    slice(s, range.start..s.len())
-}
-
-/// Panics when given start or end not on boundaries of a code point
-/// TODO: don't panic but do something sensible in that case
-pub(crate) fn slice<S>(s: &S, range: std::ops::Range<usize>) -> S
-where
-    S: UnicodeString,
-{
-    S::from_vec(s.as_ref()[range].to_vec()).expect("Invalid slice!")
 }
 
 pub(crate) fn starts_with(subject: &DomHandle, object: &DomHandle) -> bool {

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -65,7 +65,7 @@ where
     /// Deletes text in an arbitrary start..end range.
     pub fn delete_in(&mut self, start: usize, end: usize) -> ComposerUpdate<S> {
         self.state.end = Location::from(start);
-        self.replace_text_in(S::new(), start, end)
+        self.replace_text_in(S::default(), start, end)
     }
 
     /// Deletes the character after the current cursor position.
@@ -75,7 +75,7 @@ where
             self.state.end += 1;
         }
 
-        self.replace_text(S::new())
+        self.replace_text(S::default())
     }
 
     pub(crate) fn delete_nodes(&mut self, mut to_delete: Vec<DomHandle>) {
@@ -117,6 +117,6 @@ where
             self.state.start -= 1;
         }
 
-        self.replace_text(S::new())
+        self.replace_text(S::default())
     }
 }

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -19,6 +19,7 @@ use widestring::Utf16String;
 
 use crate::dom::nodes::{LineBreakNode, TextNode};
 use crate::dom::parser::parse;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomLocation, HtmlFormatter};
 use crate::{
     ComposerModel, ComposerState, DomHandle, Location, ToHtml, UnicodeString,

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -73,7 +73,7 @@ impl ComposerModel<Utf16String> {
     /// use wysiwyg::{ComposerModel, Location, ToHtml, UnicodeString};
     ///
     /// let mut model = ComposerModel::from_example_format("aa{bb}|cc");
-    /// assert_eq!(model.state.dom.to_html().to_utf8(), "aabbcc");
+    /// assert_eq!(model.state.dom.to_html().to_string(), "aabbcc");
     /// assert_eq!(model.state.start, 2);
     /// assert_eq!(model.state.end, 4);
     /// model.select(Location::from(1), Location::from(5));
@@ -180,7 +180,7 @@ impl ComposerModel<Utf16String> {
             assert!(selection_writer.is_selection_written());
         }
         let ret = formatter.finish();
-        let html = ret.to_utf8();
+        let html = ret.to_string();
 
         // Replace characters with visible ones
         html.replace('\u{200b}', "~").replace('\u{A0}', "&nbsp;")

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -201,7 +201,7 @@ impl SelectionWriter {
         if let Some(loc) = self.locations.get(&node.handle()) {
             let strings_to_add = self.state.advance(loc, node.data().len());
             for (str, i) in strings_to_add.into_iter().rev() {
-                let code_units = S::from_str(str);
+                let code_units = S::from(str);
                 f.write_at(pos + i, code_units.as_ref());
             }
         }
@@ -216,7 +216,7 @@ impl SelectionWriter {
         if let Some(loc) = self.locations.get(&node.handle()) {
             let strings_to_add = self.state.advance(loc, 1);
             for (str, i) in strings_to_add.into_iter().rev() {
-                let code_units = S::from_str(str);
+                let code_units = S::from(str);
                 // Index 1 in line breaks is actually at the end of the '<br />'
                 let i = if i == 0 { 0 } else { 6 };
                 f.write_at(pos + i, code_units.as_ref());

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -202,7 +202,7 @@ impl SelectionWriter {
             let strings_to_add = self.state.advance(loc, node.data().len());
             for (str, i) in strings_to_add.into_iter().rev() {
                 let code_units = S::from_str(str);
-                f.write_at(pos + i, code_units.as_slice());
+                f.write_at(pos + i, code_units.as_ref());
             }
         }
     }
@@ -219,7 +219,7 @@ impl SelectionWriter {
                 let code_units = S::from_str(str);
                 // Index 1 in line breaks is actually at the end of the '<br />'
                 let i = if i == 0 { 0 } else { 6 };
-                f.write_at(pos + i, code_units.as_slice());
+                f.write_at(pos + i, code_units.as_ref());
             }
         }
     }

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -14,6 +14,7 @@
 
 use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::{ContainerNodeKind, DomNode};
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{Dom, DomHandle, DomLocation, Range};
 use crate::{
     ComposerAction, ComposerModel, ComposerUpdate, InlineFormatType, Location,

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -350,7 +350,7 @@ where
     fn insert_zwspace_if_needed(node: &mut DomNode<S>) -> isize {
         if let DomNode::Text(text) = node {
             if text.data().is_empty() {
-                text.set_data(UnicodeString::from_str("\u{200B}"));
+                text.set_data("\u{200B}".into());
                 1
             } else {
                 0

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::{ContainerNodeKind, DomNode};
 use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{Dom, DomHandle, DomLocation, Range};
@@ -330,8 +329,8 @@ where
         position: usize,
     ) -> (DomNode<S>, DomNode<S>) {
         if let DomNode::Text(text_node) = node {
-            let split_data_orig = slice_to(text_node.data(), ..position);
-            let split_data_new = slice_from(text_node.data(), position..);
+            let split_data_orig = text_node.data()[..position].to_owned();
+            let split_data_new = text_node.data()[position..].to_owned();
             let mut before = DomNode::new_text(split_data_orig);
             before.set_handle(text_node.handle());
             let after = DomNode::new_text(split_data_new);

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::composer_model::base::{slice, slice_from, slice_to};
 use crate::dom::nodes::DomNode;
 use crate::dom::{DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, UnicodeString};
@@ -44,10 +43,10 @@ where
             let node = self.state.dom.lookup_node(handle);
             if let DomNode::Text(t) = node {
                 let text = t.data();
-                let before = slice_to(text, ..location.start_offset);
+                let before = text[..location.start_offset].to_owned();
                 let during =
-                    slice(text, location.start_offset..location.end_offset);
-                let after = slice_from(text, location.end_offset..);
+                    text[location.start_offset..location.end_offset].to_owned();
+                let after = text[location.end_offset..].to_owned();
                 let new_nodes = vec![
                     DomNode::new_text(before),
                     DomNode::new_link(link, vec![DomNode::new_text(during)]),

--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::dom::nodes::{ContainerNodeKind, DomNode};
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, DomLocation, Range};
 use crate::{ComposerModel, UnicodeString};
 

--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -195,7 +195,7 @@ where
                 }
                 (DomNode::Text(start_i), DomNode::Text(next_i)) => {
                     let mut new_data = start_i.data().clone();
-                    new_data.push_string(next_i.data());
+                    new_data.push(&**next_i.data());
                     let text_node = DomNode::new_text(new_data);
                     if let DomNode::Container(old_parent) =
                         dom.lookup_node_mut(&next_handle.parent_handle())

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -216,8 +216,8 @@ where
             self.state.dom.append_child(DomNode::new_list(
                 list_type,
                 vec![DomNode::Container(ContainerNode::new_list_item(
-                    S::from_str("li"),
-                    vec![DomNode::new_text(S::from_str(""))],
+                    "li".into(),
+                    vec![DomNode::new_text(S::default())],
                 ))],
             ));
             self.create_update_replace_all()
@@ -240,7 +240,7 @@ where
                 let index_in_parent = handle.index_in_parent();
                 let list_item =
                     DomNode::Container(ContainerNode::new_list_item(
-                        S::from_str("li"),
+                        "li".into(),
                         vec![DomNode::new_text(text.clone())],
                     ));
                 if index_in_parent > 0 {
@@ -305,9 +305,9 @@ where
             if let DomNode::Container(list) = list_node {
                 let add_zwsp = new_li_text.len() == 0;
                 list.append_child(DomNode::new_list_item(
-                    S::from_str("li"),
+                    "li".into(),
                     vec![DomNode::new_text(if add_zwsp {
-                        S::from_str("\u{200b}")
+                        "\u{200b}".into()
                     } else {
                         new_li_text
                     })],
@@ -338,7 +338,7 @@ where
                 if let DomNode::Container(parent) = parent_node {
                     parent.remove_child(list_handle.index_in_parent());
                     if parent.children().is_empty() {
-                        parent.append_child(DomNode::new_text(S::from_str("")));
+                        parent.append_child(DomNode::new_text("".into()));
                     }
                     let new_location = Location::from(
                         current_cursor_global_location - list_len,
@@ -357,9 +357,8 @@ where
                         self.state.dom.lookup_node_mut(&parent_handle);
                     if let DomNode::Container(parent) = parent_node {
                         // TODO: should probably append a paragraph instead
-                        parent.append_child(DomNode::new_text(S::from_str(
-                            "\u{200b}",
-                        )));
+                        parent
+                            .append_child(DomNode::new_text("\u{200b}".into()));
                         let new_location = Location::from(
                             current_cursor_global_location - li_len + 1,
                         );

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::{ContainerNode, DomNode};
 use crate::dom::to_raw_text::ToRawText;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, ListType, Location, UnicodeString};
 

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -303,7 +303,7 @@ where
             t.set_data(new_text);
             let list_node = self.state.dom.lookup_node_mut(list_handle);
             if let DomNode::Container(list) = list_node {
-                let add_zwsp = new_li_text.len() == 0;
+                let add_zwsp = new_li_text.is_empty();
                 list.append_child(DomNode::new_list_item(
                     "li".into(),
                     vec![DomNode::new_text(if add_zwsp {

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 
-use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::{ContainerNode, DomNode};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::unicode_string::UnicodeStringExt;
@@ -299,8 +298,8 @@ where
         if let DomNode::Text(ref mut t) = text_node {
             let text = t.data();
             // TODO: should slice container nodes between li and text node as well
-            let new_text = slice_to(text, ..start_offset);
-            let new_li_text = slice_from(text, end_offset..);
+            let new_text = text[..start_offset].to_owned();
+            let new_li_text = text[end_offset..].to_owned();
             t.set_data(new_text);
             let list_node = self.state.dom.lookup_node_mut(list_handle);
             if let DomNode::Container(list) = list_node {

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -215,13 +215,10 @@ where
 
                         // and replace with the new content
                         if first_text_node {
-                            new_data.push_string(&new_text);
+                            new_data.push(&*new_text);
                         }
 
-                        new_data.push_string(&slice_from(
-                            old_data,
-                            loc.end_offset..,
-                        ));
+                        new_data.push(slice_from(old_data, loc.end_offset..));
                         node.set_data(new_data);
                     }
 

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -14,6 +14,7 @@
 
 use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::DomNode;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
 

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::composer_model::base::{slice_from, slice_to};
 use crate::dom::nodes::DomNode;
 use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomHandle, DomLocation, Range};
@@ -211,14 +210,14 @@ where
                     } else {
                         // Otherwise, delete the selected text
                         let mut new_data =
-                            slice_to(old_data, ..loc.start_offset);
+                            old_data[..loc.start_offset].to_owned();
 
                         // and replace with the new content
                         if first_text_node {
-                            new_data.push(&*new_text);
+                            new_data.push(new_text.deref());
                         }
 
-                        new_data.push(slice_from(old_data, loc.end_offset..));
+                        new_data.push(&old_data[loc.end_offset..]);
                         node.set_data(new_data);
                     }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -37,7 +37,7 @@ where
 {
     pub fn new(top_level_items: Vec<DomNode<S>>) -> Self {
         let mut document = ContainerNode::new(
-            S::new(),
+            S::default(),
             ContainerNodeKind::Generic,
             None,
             top_level_items,

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -17,6 +17,7 @@ use std::fmt::Display;
 use crate::composer_model::base::{slice_from, slice_to};
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::HtmlFormatter;
 use crate::dom::{
     find_range, to_raw_text::ToRawText, DomHandle, Range, ToTree, UnicodeString,

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -365,7 +365,7 @@ where
     S: UnicodeString,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.to_html().to_utf8())
+        f.write_str(&self.to_html().to_string())
     }
 }
 
@@ -529,7 +529,7 @@ mod test {
         let d = dom(&[a(&[tn("foo")])]);
         assert_eq!(
             "<a href=\"https://element.io\">foo</a>",
-            d.to_html().to_utf8()
+            d.to_html().to_string()
         );
     }
 
@@ -538,20 +538,20 @@ mod test {
         let d = dom(&[a(&[b(&[tn("foo")]), tn(" "), i(&[tn("bar")])])]);
         assert_eq!(
             "<a href=\"https://element.io\"><b>foo</b> <i>bar</i></a>",
-            d.to_html().to_utf8()
+            d.to_html().to_string()
         );
     }
 
     #[test]
     fn inline_code_gets_formatted() {
         let d = dom(&[i_c(&[tn("some_code")])]);
-        assert_eq!("<code>some_code</code>", d.to_html().to_utf8());
+        assert_eq!("<code>some_code</code>", d.to_html().to_string());
     }
 
     #[test]
     fn html_symbols_inside_text_tags_get_escaped() {
         let d = dom(&[tn("<p>Foo & bar</p>")]);
-        assert_eq!("&lt;p&gt;Foo &amp; bar&lt;/p&gt;", d.to_html().to_utf8());
+        assert_eq!("&lt;p&gt;Foo &amp; bar&lt;/p&gt;", d.to_html().to_string());
     }
 
     #[test]
@@ -559,14 +559,14 @@ mod test {
         let d = dom(&[i_c(&[tn("<b>some</b> code")])]);
         assert_eq!(
             "<code>&lt;b&gt;some&lt;/b&gt; code</code>",
-            d.to_html().to_utf8()
+            d.to_html().to_string()
         );
     }
 
     #[test]
     fn inline_code_node_contents_do_not_get_escaped() {
         let d = dom(&[i_c(&[b(&[tn("some")]), tn(" code")])]);
-        assert_eq!("<code><b>some</b> code</code>", d.to_html().to_utf8());
+        assert_eq!("<code><b>some</b> code</code>", d.to_html().to_string());
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -14,7 +14,6 @@
 
 use std::fmt::Display;
 
-use crate::composer_model::base::{slice_from, slice_to};
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
 use crate::dom::unicode_string::UnicodeStringExt;
@@ -296,8 +295,8 @@ where
                 let old_node = self.lookup_node_mut(handle);
                 if let DomNode::Text(old_text_node) = old_node {
                     let data = old_text_node.data();
-                    let before_text = slice_to(data, ..offset);
-                    let after_text = slice_from(data, offset..);
+                    let before_text = data[..offset].to_owned();
+                    let after_text = data[offset..].to_owned();
                     old_text_node.set_data(before_text);
                     let new_text_node = DomNode::new_text(after_text);
                     let parent = self.parent(handle);

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -14,6 +14,7 @@
 
 use crate::dom::nodes::{ContainerNode, DomNode, LineBreakNode, TextNode};
 use crate::dom::range::DomLocation;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{Dom, DomHandle, FindResult, Range};
 use crate::UnicodeString;
 use std::cmp::{max, min};

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -94,7 +94,7 @@ where
     pub fn finish(self) -> S {
         let ret =
             S::from_vec(self.chars).expect("Unable to convert to unicode!");
-        S::from_str(&ret.to_utf8().replace("\u{A0}", "&nbsp;"))
+        S::from(&ret.to_utf8().replace("\u{A0}", "&nbsp;"))
     }
 
     pub fn len(&self) -> usize {

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -21,7 +21,6 @@ where
     S: UnicodeString,
 {
     chars: Vec<S::CodeUnit>,
-    known_char_data: KnownCharData<S>,
 }
 
 pub enum HtmlChar {
@@ -38,10 +37,7 @@ where
     S: UnicodeString,
 {
     pub fn new() -> Self {
-        Self {
-            chars: Vec::new(),
-            known_char_data: KnownCharData::new(),
-        }
+        Self { chars: Vec::new() }
     }
 
     pub fn chars_at(&self, range: Range<usize>) -> &[S::CodeUnit] {
@@ -54,12 +50,12 @@ where
 
     pub fn write_char(&mut self, c: HtmlChar) {
         self.chars.push(match c {
-            HtmlChar::Equal => self.known_char_data.equal,
-            HtmlChar::ForwardSlash => self.known_char_data.forward_slash,
-            HtmlChar::Gt => self.known_char_data.gt,
-            HtmlChar::Lt => self.known_char_data.lt,
-            HtmlChar::Quote => self.known_char_data.quote,
-            HtmlChar::Space => self.known_char_data.space,
+            HtmlChar::Equal => b'='.into(),
+            HtmlChar::ForwardSlash => b'/'.into(),
+            HtmlChar::Gt => b'>'.into(),
+            HtmlChar::Lt => b'<'.into(),
+            HtmlChar::Quote => b'"'.into(),
+            HtmlChar::Space => b' '.into(),
         });
     }
 
@@ -99,33 +95,5 @@ where
 
     pub fn len(&self) -> usize {
         self.chars.len()
-    }
-}
-
-struct KnownCharData<S>
-where
-    S: UnicodeString,
-{
-    equal: S::CodeUnit,
-    forward_slash: S::CodeUnit,
-    gt: S::CodeUnit,
-    lt: S::CodeUnit,
-    quote: S::CodeUnit,
-    space: S::CodeUnit,
-}
-
-impl<S> KnownCharData<S>
-where
-    S: UnicodeString,
-{
-    fn new() -> Self {
-        Self {
-            equal: S::c_from_char('='),
-            forward_slash: S::c_from_char('/'),
-            gt: S::c_from_char('>'),
-            lt: S::c_from_char('<'),
-            quote: S::c_from_char('"'),
-            space: S::c_from_char(' '),
-        }
     }
 }

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -90,7 +90,7 @@ where
     pub fn finish(self) -> S {
         let ret =
             S::from_vec(self.chars).expect("Unable to convert to unicode!");
-        S::from(&ret.to_utf8().replace("\u{A0}", "&nbsp;"))
+        S::from(&ret.to_utf8().replace('\u{A0}', "&nbsp;"))
     }
 
     pub fn len(&self) -> usize {

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -54,14 +54,12 @@ where
 
     pub fn write_char(&mut self, c: HtmlChar) {
         self.chars.push(match c {
-            HtmlChar::Equal => self.known_char_data.equal.clone(),
-            HtmlChar::ForwardSlash => {
-                self.known_char_data.forward_slash.clone()
-            }
-            HtmlChar::Gt => self.known_char_data.gt.clone(),
-            HtmlChar::Lt => self.known_char_data.lt.clone(),
-            HtmlChar::Quote => self.known_char_data.quote.clone(),
-            HtmlChar::Space => self.known_char_data.space.clone(),
+            HtmlChar::Equal => self.known_char_data.equal,
+            HtmlChar::ForwardSlash => self.known_char_data.forward_slash,
+            HtmlChar::Gt => self.known_char_data.gt,
+            HtmlChar::Lt => self.known_char_data.lt,
+            HtmlChar::Quote => self.known_char_data.quote,
+            HtmlChar::Space => self.known_char_data.space,
         });
     }
 

--- a/crates/wysiwyg/src/dom/html_formatter.rs
+++ b/crates/wysiwyg/src/dom/html_formatter.rs
@@ -90,7 +90,7 @@ where
     pub fn finish(self) -> S {
         let ret =
             S::from_vec(self.chars).expect("Unable to convert to unicode!");
-        S::from(&ret.to_utf8().replace('\u{A0}', "&nbsp;"))
+        S::from(&ret.to_string().replace('\u{A0}', "&nbsp;"))
     }
 
     pub fn len(&self) -> usize {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -89,7 +89,7 @@ where
         children: Vec<DomNode<S>>,
     ) -> Self {
         Self {
-            name: UnicodeString::from_str(format.tag()),
+            name: format.tag().into(),
             kind: ContainerNodeKind::Formatting(format),
             attrs: None,
             children,
@@ -99,7 +99,7 @@ where
 
     pub fn new_list(list_type: ListType, children: Vec<DomNode<S>>) -> Self {
         Self {
-            name: S::from_str(list_type.tag()),
+            name: list_type.tag().into(),
             kind: ContainerNodeKind::List,
             attrs: None,
             children,
@@ -246,9 +246,9 @@ where
 
     pub fn new_link(url: S, children: Vec<DomNode<S>>) -> Self {
         Self {
-            name: S::from_str("a"),
+            name: "a".into(),
             kind: ContainerNodeKind::Link(url.clone()),
-            attrs: Some(vec![(S::from_str("href"), url)]),
+            attrs: Some(vec![("href".into(), url)]),
             children,
             handle: DomHandle::new_unset(),
         }
@@ -267,7 +267,7 @@ where
     pub(crate) fn set_list_type(&mut self, list_type: ListType) {
         match self.kind {
             ContainerNodeKind::List => {
-                self.name = S::from_str(list_type.tag());
+                self.name = list_type.tag().into();
             }
             _ => panic!(
                 "Setting list type to a non-list container is not allowed"
@@ -330,7 +330,7 @@ where
     S: UnicodeString,
 {
     fn to_raw_text(&self) -> S {
-        let mut text = S::from_str("");
+        let mut text = S::default();
         for child in &self.children {
             text.push_string(&child.to_raw_text());
         }
@@ -473,6 +473,6 @@ mod test {
     where
         S: UnicodeString,
     {
-        DomNode::new_text(S::from_str(content))
+        DomNode::new_text(content.into())
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -289,15 +289,15 @@ where
         let name = self.name();
         if !name.is_empty() {
             formatter.write_char(HtmlChar::Lt);
-            formatter.write(name.as_slice());
+            formatter.write(name.as_ref());
             if let Some(attrs) = &self.attrs {
                 for attr in attrs {
                     formatter.write_char(HtmlChar::Space);
                     let (attr_name, value) = attr;
-                    formatter.write(attr_name.as_slice());
+                    formatter.write(attr_name.as_ref());
                     formatter.write_char(HtmlChar::Equal);
                     formatter.write_char(HtmlChar::Quote);
-                    formatter.write(value.as_slice());
+                    formatter.write(value.as_ref());
                     formatter.write_char(HtmlChar::Quote);
                 }
             }
@@ -319,7 +319,7 @@ where
         if !name.is_empty() {
             formatter.write_char(HtmlChar::Lt);
             formatter.write_char(HtmlChar::ForwardSlash);
-            formatter.write(name.as_slice());
+            formatter.write(name.as_ref());
             formatter.write_char(HtmlChar::Gt);
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -258,7 +258,7 @@ where
     pub fn is_empty_list_item(&self) -> bool {
         match self.kind {
             ContainerNodeKind::ListItem => {
-                let raw_text = self.to_raw_text().to_utf8();
+                let raw_text = self.to_raw_text().to_string();
                 raw_text.is_empty() || raw_text == "\u{200b}"
             }
             _ => false,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -333,7 +333,7 @@ where
     fn to_raw_text(&self) -> S {
         let mut text = S::default();
         for child in &self.children {
-            text.push_string(&child.to_raw_text());
+            text.push(child.to_raw_text());
         }
         text
     }
@@ -355,7 +355,7 @@ where
             if i < self.children.len() - 1 {
                 new_positions.push(self.handle.raw().len());
             }
-            tree_part.push_string(&child.to_tree_display(new_positions));
+            tree_part.push(child.to_tree_display(new_positions));
         }
         tree_part
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -19,6 +19,7 @@ use crate::dom::nodes::dom_node::DomNode;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{HtmlChar, UnicodeString};
 use crate::{InlineFormatType, ListType};
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -59,7 +59,7 @@ where
         DomNode::Container(
             ContainerNode::new_formatting_from_tag(format.clone(), children)
                 .unwrap_or_else(|| {
-                    panic!("Unknown format tag {}", format.to_utf8())
+                    panic!("Unknown format tag {}", format.to_string())
                 }),
         )
     }
@@ -131,7 +131,7 @@ where
     pub(crate) fn is_placeholder_text_node(&self) -> bool {
         match self {
             DomNode::Text(n) => {
-                n.data().len() == 1 && n.data().to_utf8() == "\u{200b}"
+                n.data().len() == 1 && n.data().to_string() == "\u{200b}"
             }
             _ => false,
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -19,6 +19,7 @@ use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::UnicodeString;
 use crate::{InlineFormatType, ListType};
 

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -76,7 +76,7 @@ where
     ) {
         let cur_pos = f.len();
         f.write_char(HtmlChar::Lt);
-        f.write(self.name().as_slice());
+        f.write(self.name().as_ref());
         f.write_char(HtmlChar::Space);
         f.write_char(HtmlChar::ForwardSlash);
         f.write_char(HtmlChar::Gt);

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -47,7 +47,7 @@ where
     }
 
     pub fn name(&self) -> S {
-        S::from_str("br")
+        "br".into()
     }
 
     pub fn handle(&self) -> DomHandle {
@@ -91,7 +91,7 @@ where
     S: UnicodeString,
 {
     fn to_raw_text(&self) -> S {
-        S::from_str("\\n")
+        "\\n".into()
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::composer_model::example_format::SelectionWriter;
+use crate::dom::unicode_string::UnicodeStringExt;
 use html_escape;
 
 use crate::dom::dom_handle::DomHandle;

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -96,12 +96,12 @@ where
         }
         if is_last_node_in_parent && needs_to_replace {
             current_range.end = formatter.len();
-            ranges_to_replace.push((current_range.clone(), whitespaces));
+            ranges_to_replace.push((current_range, whitespaces));
         }
 
         for (range, whitespaces) in ranges_to_replace.iter().rev() {
             let replacement: Vec<S::CodeUnit> =
-                (0..*whitespaces).map(|_| nbsp.clone()).collect();
+                (0..*whitespaces).map(|_| nbsp).collect();
             formatter.write_at_range(range.clone(), &replacement);
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -119,8 +119,7 @@ where
     ) {
         let cur_pos = f.len();
         let string = self.data.to_utf8();
-        let mut escaped = String::new();
-        html_escape::encode_text_to_string(&string, &mut escaped);
+        let escaped = html_escape::encode_text(&string);
         f.write(S::from_str(&escaped).as_slice());
         Self::handle_several_whitespaces(f, cur_pos, is_last_node_in_parent);
         if let Some(selection_writer) = selection_writer {

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -120,7 +120,7 @@ where
         let cur_pos = f.len();
         let string = self.data.to_utf8();
         let escaped = html_escape::encode_text(&string);
-        f.write(S::from_str(&escaped).as_ref());
+        f.write(S::from(&escaped).as_ref());
         Self::handle_several_whitespaces(f, cur_pos, is_last_node_in_parent);
         if let Some(selection_writer) = selection_writer {
             selection_writer.write_selection_text_node(f, cur_pos, self);
@@ -142,10 +142,10 @@ where
     S: UnicodeString,
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
-        let mut description = S::from_str("\"");
+        let mut description = S::from("\"");
         let text = &self.data.to_utf8().replace('\u{200b}', "~");
-        description.push_string(&S::from_str(text));
-        description.push_string(&S::from_str("\""));
+        description.push_string(&text.as_str().into());
+        description.push_string(&"\"".into());
         return self.tree_line(
             description,
             self.handle.raw().len(),

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -71,7 +71,7 @@ where
         let mut current_range = usize::MAX..usize::MAX;
         let mut whitespaces: usize = 0;
         let mut needs_to_replace = false;
-        let w = S::c_from_char(' ');
+        let w = S::CodeUnit::from(b' ');
         let nbsp = S::c_from_char('\u{A0}');
         for (i, c) in formatter.chars_from(pos..).iter().enumerate() {
             if *c == w || *c == nbsp {

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -118,7 +118,7 @@ where
         is_last_node_in_parent: bool,
     ) {
         let cur_pos = f.len();
-        let string = self.data.to_utf8();
+        let string = self.data.to_string();
         let escaped = html_escape::encode_text(&string);
         f.write(S::from(&escaped).as_ref());
         Self::handle_several_whitespaces(f, cur_pos, is_last_node_in_parent);
@@ -143,7 +143,7 @@ where
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
         let mut description = S::from("\"");
-        let text = &self.data.to_utf8().replace('\u{200b}', "~");
+        let text = &self.data.to_string().replace('\u{200b}', "~");
         description.push_string(&text.as_str().into());
         description.push_string(&"\"".into());
         return self.tree_line(

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -145,8 +145,8 @@ where
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
         let mut description = S::from("\"");
         let text = &self.data.to_string().replace('\u{200b}', "~");
-        description.push_string(&text.as_str().into());
-        description.push_string(&"\"".into());
+        description.push(text.as_str());
+        description.push('"');
         return self.tree_line(
             description,
             self.handle.raw().len(),

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -120,7 +120,7 @@ where
         let cur_pos = f.len();
         let string = self.data.to_utf8();
         let escaped = html_escape::encode_text(&string);
-        f.write(S::from_str(&escaped).as_slice());
+        f.write(S::from_str(&escaped).as_ref());
         Self::handle_several_whitespaces(f, cur_pos, is_last_node_in_parent);
         if let Some(selection_writer) = selection_writer {
             selection_writer.write_selection_text_node(f, cur_pos, self);

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -66,11 +66,8 @@ where
         S: UnicodeString,
     {
         DomNode::Container(
-            ContainerNode::new_formatting_from_tag(
-                S::from_str(tag),
-                Vec::new(),
-            )
-            .unwrap_or_else(|| panic!("Unknown format tag {}", tag)),
+            ContainerNode::new_formatting_from_tag(tag.into(), Vec::new())
+                .unwrap_or_else(|| panic!("Unknown format tag {}", tag)),
         )
     }
 
@@ -88,7 +85,7 @@ where
         S: UnicodeString,
     {
         DomNode::Container(ContainerNode::new_link(
-            S::from_str(child.get_attr("href").unwrap_or("")),
+            child.get_attr("href").unwrap_or("").into(),
             Vec::new(),
         ))
     }
@@ -99,7 +96,7 @@ where
         S: UnicodeString,
     {
         DomNode::Container(ContainerNode::new_list(
-            ListType::try_from(S::from_str(tag)).unwrap(),
+            ListType::try_from(S::from(tag)).unwrap(),
             Vec::new(),
         ))
     }
@@ -109,10 +106,7 @@ where
     where
         S: UnicodeString,
     {
-        DomNode::Container(ContainerNode::new_list_item(
-            S::from_str(tag),
-            Vec::new(),
-        ))
+        DomNode::Container(ContainerNode::new_list_item(tag.into(), Vec::new()))
     }
 
     /// Copy all panode's information into node (now we know it's a container).
@@ -174,9 +168,9 @@ where
                     panic!("Found a document inside a document!")
                 }
                 PaDomNode::Text(text) => {
-                    node.append_child(DomNode::new_text(S::from_str(
-                        &text.content,
-                    )));
+                    node.append_child(DomNode::new_text(
+                        text.content.as_str().into(),
+                    ));
                 }
             }
         }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -221,7 +221,7 @@ mod test {
         fn roundtrips(&self) {
             let subject = self.subject.as_ref();
             let dom = parse::<Utf16String>(subject).unwrap();
-            let output = restore_whitespace(&dom.to_html().to_utf8());
+            let output = restore_whitespace(&dom.to_html().to_string());
             if output != subject {
                 AssertionFailure::from_spec(self)
                     .with_expected(String::from(subject))

--- a/crates/wysiwyg/src/dom/to_tree.rs
+++ b/crates/wysiwyg/src/dom/to_tree.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
-
 use super::unicode_string::UnicodeStringExt;
 use super::UnicodeString;
+
+const DOUBLE_WHITESPACE: &str = "\u{0020}\u{0020}";
+const UP_RIGHT_AND_GT: &str = "\u{2514}\u{003E}";
+const VERTICAL_RIGHT_AND_GT: &str = "\u{251C}\u{003E}";
+const VERTICAL_AND_WHITESPACE: &str = "\u{2502}\u{0020}";
 
 pub trait ToTree<S>
 where
@@ -43,47 +46,18 @@ where
         for i in 0..depth {
             if i == depth - 1 {
                 if continuous_positions.contains(&i) {
-                    tree_part
-                        .push_string(&TreeSymbols::vertical_right_and_gt());
+                    tree_part.push(VERTICAL_RIGHT_AND_GT);
                 } else {
-                    tree_part.push_string(&TreeSymbols::up_right_and_gt());
+                    tree_part.push(UP_RIGHT_AND_GT);
                 }
             } else if continuous_positions.contains(&i) {
-                tree_part.push_string(&TreeSymbols::vertical_and_whitespace());
+                tree_part.push(VERTICAL_AND_WHITESPACE);
             } else {
-                tree_part.push_string(&TreeSymbols::double_whitespace());
+                tree_part.push(DOUBLE_WHITESPACE);
             }
         }
-        tree_part.push_string(&description);
-        tree_part.push_string(&"\n".into());
+        tree_part.push(description);
+        tree_part.push('\n');
         tree_part
-    }
-}
-
-struct TreeSymbols<S>
-where
-    S: UnicodeString,
-{
-    phantom_data: PhantomData<S>,
-}
-
-impl<S> TreeSymbols<S>
-where
-    S: UnicodeString,
-{
-    fn double_whitespace() -> S {
-        "\u{0020}\u{0020}".into()
-    }
-
-    fn up_right_and_gt() -> S {
-        "\u{2514}\u{003E}".into()
-    }
-
-    fn vertical_right_and_gt() -> S {
-        "\u{251C}\u{003E}".into()
-    }
-
-    fn vertical_and_whitespace() -> S {
-        "\u{2502}\u{0020}".into()
     }
 }

--- a/crates/wysiwyg/src/dom/to_tree.rs
+++ b/crates/wysiwyg/src/dom/to_tree.rs
@@ -38,7 +38,7 @@ where
         depth: usize,
         continuous_positions: Vec<usize>,
     ) -> S {
-        let mut tree_part = S::from_str("");
+        let mut tree_part = S::default();
         for i in 0..depth {
             if i == depth - 1 {
                 if continuous_positions.contains(&i) {
@@ -54,7 +54,7 @@ where
             }
         }
         tree_part.push_string(&description);
-        tree_part.push_string(&S::from_str("\n"));
+        tree_part.push_string(&"\n".into());
         tree_part
     }
 }
@@ -71,18 +71,18 @@ where
     S: UnicodeString,
 {
     fn double_whitespace() -> S {
-        S::from_str("\u{0020}\u{0020}")
+        "\u{0020}\u{0020}".into()
     }
 
     fn up_right_and_gt() -> S {
-        S::from_str("\u{2514}\u{003E}")
+        "\u{2514}\u{003E}".into()
     }
 
     fn vertical_right_and_gt() -> S {
-        S::from_str("\u{251C}\u{003E}")
+        "\u{251C}\u{003E}".into()
     }
 
     fn vertical_and_whitespace() -> S {
-        S::from_str("\u{2502}\u{0020}")
+        "\u{2502}\u{0020}".into()
     }
 }

--- a/crates/wysiwyg/src/dom/to_tree.rs
+++ b/crates/wysiwyg/src/dom/to_tree.rs
@@ -14,6 +14,7 @@
 
 use std::marker::PhantomData;
 
+use super::unicode_string::UnicodeStringExt;
 use super::UnicodeString;
 
 pub trait ToTree<S>

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -30,8 +30,6 @@ pub trait UnicodeString:
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String>;
 
-    fn is_empty(&self) -> bool;
-
     /// Convert this character to a code unit.
     /// Panics if this character requires more than one code unit
     fn c_from_char(ch: char) -> Self::CodeUnit;
@@ -39,8 +37,6 @@ pub trait UnicodeString:
     fn to_utf8(&self) -> String;
 
     fn push_string(&mut self, s: &Self);
-
-    fn len(&self) -> usize;
 }
 
 impl UnicodeString for String {
@@ -48,10 +44,6 @@ impl UnicodeString for String {
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         String::from_utf8(v.into()).map_err(|e| e.to_string())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
     }
 
     fn c_from_char(ch: char) -> Self::CodeUnit {
@@ -68,10 +60,6 @@ impl UnicodeString for String {
     fn push_string(&mut self, s: &Self) {
         self.push_str(s)
     }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
 }
 
 impl UnicodeString for Utf16String {
@@ -79,10 +67,6 @@ impl UnicodeString for Utf16String {
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf16String::from_vec(v.into()).map_err(|e| e.to_string())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
     }
 
     fn c_from_char(ch: char) -> Self::CodeUnit {
@@ -100,10 +84,6 @@ impl UnicodeString for Utf16String {
     fn push_string(&mut self, s: &Self) {
         self.push_utfstr(s.as_utfstr())
     }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
 }
 
 impl UnicodeString for Utf32String {
@@ -111,10 +91,6 @@ impl UnicodeString for Utf32String {
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf32String::from_vec(v.into()).map_err(|e| e.to_string())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
     }
 
     fn c_from_char(ch: char) -> Self::CodeUnit {
@@ -132,8 +108,19 @@ impl UnicodeString for Utf32String {
     fn push_string(&mut self, s: &Self) {
         self.push_utfstr(s.as_utfstr())
     }
+}
+
+pub trait UnicodeStringExt: UnicodeString {
+    fn is_empty(&self) -> bool;
+    fn len(&self) -> usize;
+}
+
+impl<S: UnicodeString> UnicodeStringExt for S {
+    fn is_empty(&self) -> bool {
+        self.as_ref().is_empty()
+    }
 
     fn len(&self) -> usize {
-        self.len()
+        self.as_ref().len()
     }
 }

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -19,11 +19,14 @@ use widestring::{Utf16String, Utf32String};
 /// We implement this for String, Utf16String and Utf32String (from the
 /// widestring crate).
 pub trait UnicodeString:
-    Clone + std::fmt::Debug + Default + PartialEq + AsRef<[Self::CodeUnit]>
+    Clone
+    + std::fmt::Debug
+    + Default
+    + PartialEq
+    + AsRef<[Self::CodeUnit]>
+    + for<'a> From<&'a str>
 {
     type CodeUnit: Copy + PartialEq;
-
-    fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self;
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String>;
 
@@ -42,10 +45,6 @@ pub trait UnicodeString:
 
 impl UnicodeString for String {
     type CodeUnit = u8;
-
-    fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
-        String::from(s.as_ref())
-    }
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         String::from_utf8(v.into()).map_err(|e| e.to_string())
@@ -78,10 +77,6 @@ impl UnicodeString for String {
 impl UnicodeString for Utf16String {
     type CodeUnit = u16;
 
-    fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
-        Utf16String::from_str(s)
-    }
-
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf16String::from_vec(v.into()).map_err(|e| e.to_string())
     }
@@ -113,10 +108,6 @@ impl UnicodeString for Utf16String {
 
 impl UnicodeString for Utf32String {
     type CodeUnit = u32;
-
-    fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
-        Utf32String::from_str(s)
-    }
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf32String::from_vec(v.into()).map_err(|e| e.to_string())

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -18,7 +18,9 @@ use widestring::{Utf16String, Utf32String};
 /// contain valid Unicode, and allow slicing by code unit positions.
 /// We implement this for String, Utf16String and Utf32String (from the
 /// widestring crate).
-pub trait UnicodeString: Clone + std::fmt::Debug + Default + PartialEq {
+pub trait UnicodeString:
+    Clone + std::fmt::Debug + Default + PartialEq + AsRef<[Self::CodeUnit]>
+{
     type CodeUnit: Copy + PartialEq;
 
     fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self;
@@ -30,8 +32,6 @@ pub trait UnicodeString: Clone + std::fmt::Debug + Default + PartialEq {
     /// Convert this character to a code unit.
     /// Panics if this character requires more than one code unit
     fn c_from_char(ch: char) -> Self::CodeUnit;
-
-    fn as_slice(&self) -> &[Self::CodeUnit];
 
     fn to_utf8(&self) -> String;
 
@@ -60,10 +60,6 @@ impl UnicodeString for String {
         let mut buf = [0; 1];
         ch.encode_utf8(&mut buf);
         buf[0]
-    }
-
-    fn as_slice(&self) -> &[Self::CodeUnit] {
-        self.as_bytes()
     }
 
     fn to_utf8(&self) -> String {
@@ -101,10 +97,6 @@ impl UnicodeString for Utf16String {
         ret.into_vec()[0]
     }
 
-    fn as_slice(&self) -> &[Self::CodeUnit] {
-        self.as_slice()
-    }
-
     fn to_utf8(&self) -> String {
         // Unwrap can't fail since we encode as UTF-8.
         String::from_utf8(self.encode_utf8().collect()).unwrap()
@@ -139,10 +131,6 @@ impl UnicodeString for Utf32String {
         ret.push(ch);
         assert!(ret.len() == 1);
         ret.into_vec()[0]
-    }
-
-    fn as_slice(&self) -> &[Self::CodeUnit] {
-        self.as_slice()
     }
 
     fn to_utf8(&self) -> String {

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -21,6 +21,7 @@ use widestring::{Utf16String, Utf32String};
 pub trait UnicodeString:
     Clone
     + std::fmt::Debug
+    + std::fmt::Display
     + Default
     + PartialEq
     + AsRef<[Self::CodeUnit]>
@@ -33,8 +34,6 @@ pub trait UnicodeString:
     /// Convert this character to a code unit.
     /// Panics if this character requires more than one code unit
     fn c_from_char(ch: char) -> Self::CodeUnit;
-
-    fn to_utf8(&self) -> String;
 
     fn push_string(&mut self, s: &Self);
 }
@@ -51,10 +50,6 @@ impl UnicodeString for String {
         let mut buf = [0; 1];
         ch.encode_utf8(&mut buf);
         buf[0]
-    }
-
-    fn to_utf8(&self) -> String {
-        self.clone()
     }
 
     fn push_string(&mut self, s: &Self) {
@@ -76,11 +71,6 @@ impl UnicodeString for Utf16String {
         ret.into_vec()[0]
     }
 
-    fn to_utf8(&self) -> String {
-        // Unwrap can't fail since we encode as UTF-8.
-        String::from_utf8(self.encode_utf8().collect()).unwrap()
-    }
-
     fn push_string(&mut self, s: &Self) {
         self.push_utfstr(s.as_utfstr())
     }
@@ -98,11 +88,6 @@ impl UnicodeString for Utf32String {
         ret.push(ch);
         assert!(ret.len() == 1);
         ret.into_vec()[0]
-    }
-
-    fn to_utf8(&self) -> String {
-        // Unwrap can't fail since we encode as UTF-8.
-        String::from_utf8(self.encode_utf8().collect()).unwrap()
     }
 
     fn push_string(&mut self, s: &Self) {

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -19,7 +19,7 @@ use widestring::{Utf16String, Utf32String};
 /// We implement this for String, Utf16String and Utf32String (from the
 /// widestring crate).
 pub trait UnicodeString: Clone + std::fmt::Debug + PartialEq {
-    type CodeUnit: Clone + PartialEq;
+    type CodeUnit: Copy + PartialEq;
 
     fn new() -> Self;
 

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -18,10 +18,8 @@ use widestring::{Utf16String, Utf32String};
 /// contain valid Unicode, and allow slicing by code unit positions.
 /// We implement this for String, Utf16String and Utf32String (from the
 /// widestring crate).
-pub trait UnicodeString: Clone + std::fmt::Debug + PartialEq {
+pub trait UnicodeString: Clone + std::fmt::Debug + Default + PartialEq {
     type CodeUnit: Copy + PartialEq;
-
-    fn new() -> Self;
 
     fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self;
 
@@ -44,10 +42,6 @@ pub trait UnicodeString: Clone + std::fmt::Debug + PartialEq {
 
 impl UnicodeString for String {
     type CodeUnit = u8;
-
-    fn new() -> Self {
-        String::new()
-    }
 
     fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
         String::from(s.as_ref())
@@ -88,10 +82,6 @@ impl UnicodeString for String {
 impl UnicodeString for Utf16String {
     type CodeUnit = u16;
 
-    fn new() -> Self {
-        Utf16String::new()
-    }
-
     fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
         Utf16String::from_str(s)
     }
@@ -131,10 +121,6 @@ impl UnicodeString for Utf16String {
 
 impl UnicodeString for Utf32String {
     type CodeUnit = u32;
-
-    fn new() -> Self {
-        Utf32String::new()
-    }
 
     fn from_str<T: AsRef<str> + ?Sized>(s: &T) -> Self {
         Utf32String::from_str(s)

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -31,6 +31,9 @@ pub trait UnicodeString:
     + for<'a> From<&'a str>
     + Deref
     + for<'a> Extend<&'a <Self as Deref>::Target>
+    + Extend<Self>
+    + Extend<char>
+    + for<'a> Extend<&'a str>
 {
     type CodeUnit: Copy + From<u8> + PartialEq;
 
@@ -87,14 +90,19 @@ impl UnicodeString for Utf32String {
 }
 
 pub trait UnicodeStringExt: UnicodeString {
-    fn push_string(&mut self, s: &Self);
+    fn push<T>(&mut self, s: T)
+    where
+        Self: Extend<T>;
     fn is_empty(&self) -> bool;
     fn len(&self) -> usize;
 }
 
 impl<S: UnicodeString> UnicodeStringExt for S {
-    fn push_string(&mut self, s: &Self) {
-        self.extend(iter::once(s.deref()));
+    fn push<T>(&mut self, s: T)
+    where
+        Self: Extend<T>,
+    {
+        self.extend(iter::once(s))
     }
 
     fn is_empty(&self) -> bool {

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -26,7 +26,7 @@ pub trait UnicodeString:
     + AsRef<[Self::CodeUnit]>
     + for<'a> From<&'a str>
 {
-    type CodeUnit: Copy + PartialEq;
+    type CodeUnit: Copy + From<u8> + PartialEq;
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String>;
 

--- a/crates/wysiwyg/src/format_type.rs
+++ b/crates/wysiwyg/src/format_type.rs
@@ -37,14 +37,14 @@ impl InlineFormatType {
 
 impl<S: UnicodeString> From<S> for InlineFormatType {
     fn from(value: S) -> Self {
-        match value.to_utf8().as_str() {
+        match value.to_string().as_str() {
             "b" | "strong" => InlineFormatType::Bold,
             "i" | "em" => InlineFormatType::Italic,
             "del" => InlineFormatType::StrikeThrough,
             "u" => InlineFormatType::Underline,
             "code" => InlineFormatType::InlineCode,
             _ => {
-                panic!("Unknown format type {}", value.to_utf8().as_str());
+                panic!("Unknown format type {}", value.to_string().as_str());
             }
         }
     }

--- a/crates/wysiwyg/src/list_type.rs
+++ b/crates/wysiwyg/src/list_type.rs
@@ -31,11 +31,11 @@ impl ListType {
 
 impl<S: UnicodeString> From<S> for ListType {
     fn from(value: S) -> Self {
-        match value.to_utf8().as_str() {
+        match value.to_string().as_str() {
             "ol" => ListType::Ordered,
             "ul" => ListType::Unordered,
             _ => {
-                panic!("Unknown list type {}", value.to_utf8().as_str());
+                panic!("Unknown list type {}", value.to_string().as_str());
             }
         }
     }

--- a/crates/wysiwyg/src/tests/testutils_composer_model.rs
+++ b/crates/wysiwyg/src/tests/testutils_composer_model.rs
@@ -33,5 +33,5 @@ pub(crate) fn restore_whitespace(text: &String) -> String {
 }
 
 pub(crate) fn restore_whitespace_u16(text: &Utf16String) -> Utf16String {
-    Utf16String::from(restore_whitespace(&text.to_utf8()))
+    Utf16String::from(restore_whitespace(&text.to_string()))
 }

--- a/crates/wysiwyg/src/tests/testutils_composer_model.rs
+++ b/crates/wysiwyg/src/tests/testutils_composer_model.rs
@@ -29,7 +29,7 @@ pub fn tx(model: &ComposerModel<Utf16String>) -> String {
 }
 
 pub(crate) fn restore_whitespace(text: &String) -> String {
-    text.replace("&nbsp;", " ").replace("\u{A0}", " ")
+    text.replace("&nbsp;", " ").replace('\u{A0}', " ")
 }
 
 pub(crate) fn restore_whitespace_u16(text: &Utf16String) -> Utf16String {


### PR DESCRIPTION
The remaining two methods can also be removed (or replaced) by rewriting `HtmlFormatter` to use a `UnicodeString` as a buffer rather than a `Vec` of `CodeUnit`s.

But I think this is enough for one PR. Let me know if you think any of these changes are too weird / make the code harder to read!