### PR TITLE
Fix enter with no text node

### DIFF
--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -76,6 +76,11 @@ where
             } else {
                 self.do_enter_in_text(handle, location.start_offset)
             }
+        } else if leaves.len() == 0 {
+            // Selection doesn't contain any text node.
+            // Create a new empty text node first.
+            self.do_replace_text_in(S::default(), range.start(), range.end());
+            self.enter()
         } else {
             panic!("Unexpected multiple nodes on a 0 length selection")
         }

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -16,7 +16,35 @@
 
 use widestring::Utf16String;
 
-use crate::tests::testutils_composer_model::{cm, tx};
+use crate::{
+    tests::testutils_composer_model::{cm, tx},
+    ComposerModel,
+};
+
+#[test]
+fn pressing_enter_with_a_brand_new_model() {
+    let mut model = ComposerModel::new();
+    model.enter();
+    assert_eq!(tx(&model), "<br />|");
+}
+
+#[test]
+fn pressing_enter_after_replacing_with_empty_html() {
+    let mut model = ComposerModel::new();
+    model.replace_all_html(&Utf16String::new());
+    model.enter();
+    assert_eq!(tx(&model), "<br />|");
+}
+
+#[test]
+#[ignore] // TODO: crashes on double empty text node, should be fixed by backspace_merges_text_nodes
+fn pressing_enter_after_backspacing_a_line_break() {
+    let mut model = cm("|");
+    model.enter();
+    model.backspace();
+    model.enter();
+    assert_eq!(tx(&model), "<br />|");
+}
 
 #[test]
 fn pressing_enter_with_an_empty_model_inserts_a_line_break() {


### PR DESCRIPTION
Fixes an issue with pressing enter when no text node are detected at current selection (completely empty model)
Add a non-passing test for similar crash with doubled empty text node after backspacing on model containing only a line break. 