### PR TITLE
Forbid empty text nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -310,10 +310,10 @@ where
         if loc.is_start() {
             let (before, middle) =
                 Self::split_text_node(node, loc.start_offset);
-            (before, middle.unwrap_or(DomNode::new_empty_text()), None)
+            (before, middle.unwrap_or(DomNode::new_zwsp()), None)
         } else if loc.is_end() {
             let (middle, after) = Self::split_text_node(node, loc.end_offset);
-            (None, middle.unwrap_or(DomNode::new_empty_text()), after)
+            (None, middle.unwrap_or(DomNode::new_zwsp()), after)
         } else {
             let (before, middle) =
                 Self::split_text_node(node, loc.start_offset);
@@ -321,7 +321,7 @@ where
                 middle.unwrap(),
                 loc.end_offset - loc.start_offset,
             );
-            (before, middle.unwrap_or(DomNode::new_empty_text()), after)
+            (before, middle.unwrap_or(DomNode::new_zwsp()), after)
         }
     }
 

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::dom::nodes::DomNode;
+use crate::dom::unicode_string::UnicodeStringExt;
 use crate::dom::{DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, UnicodeString};
 
@@ -47,11 +48,17 @@ where
                 let during =
                     text[location.start_offset..location.end_offset].to_owned();
                 let after = text[location.end_offset..].to_owned();
-                let new_nodes = vec![
-                    DomNode::new_text(before),
-                    DomNode::new_link(link, vec![DomNode::new_text(during)]),
-                    DomNode::new_text(after),
-                ];
+                let mut new_nodes = Vec::new();
+                if !before.is_empty() {
+                    new_nodes.push(DomNode::new_text(before));
+                }
+                new_nodes.push(DomNode::new_link(
+                    link,
+                    vec![DomNode::new_text(during)],
+                ));
+                if !after.is_empty() {
+                    new_nodes.push(DomNode::new_text(after));
+                }
                 self.state.dom.replace(handle, new_nodes);
                 self.create_update_replace_all()
             } else {

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -51,7 +51,7 @@ where
                 );
                 self.create_update_replace_all()
             } else {
-                self.do_backspace()
+                self.do_backspace(true)
             }
         } else {
             panic!("No list item found")

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -221,7 +221,7 @@ where
                 list_type,
                 vec![DomNode::Container(ContainerNode::new_list_item(
                     "li".into(),
-                    vec![DomNode::new_empty_text()],
+                    vec![DomNode::new_zwsp()],
                 ))],
             ));
             self.create_update_replace_all()
@@ -323,9 +323,8 @@ where
                     })],
                 ));
                 if add_zwsp {
-                    let to_add = 1; //if location == text.len() { 1 } else { 2 };
-                    self.state.start = Location::from(location + to_add);
-                    self.state.end = Location::from(location + to_add);
+                    self.state.start = Location::from(location + 1);
+                    self.state.end = self.state.start.clone();
                 }
             }
         }
@@ -352,7 +351,7 @@ where
                         parent.append_child(DomNode::new_text(S::new_zwsp()));
                     }
                     let new_location = Location::from(
-                        current_cursor_global_location - list_len,
+                        current_cursor_global_location - list_len + 1,
                     );
                     self.state.start = new_location;
                     self.state.end = new_location;

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -91,6 +91,18 @@ where
         }
     }
 
+    pub fn remove(&mut self, node_handle: &DomHandle) {
+        let parent_node = self.lookup_node_mut(&node_handle.parent_handle());
+        match parent_node {
+            DomNode::Container(parent) => {
+                let index = node_handle.index_in_parent();
+                parent.remove_child(index);
+            }
+            DomNode::Text(_) => panic!("Text nodes can't have children"),
+            DomNode::LineBreak(_) => panic!("Line breaks can't have children"),
+        }
+    }
+
     /// Removes node at given handle from the dom, and if it has children
     /// moves them to its parent container children.
     pub fn remove_and_keep_children(&mut self, node_handle: &DomHandle) {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -16,6 +16,7 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
 use crate::dom::nodes::dom_node::DomNode;
+use crate::dom::nodes::text_node::ZWSP;
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
@@ -259,7 +260,7 @@ where
         match self.kind {
             ContainerNodeKind::ListItem => {
                 let raw_text = self.to_raw_text().to_string();
-                raw_text.is_empty() || raw_text == "\u{200b}"
+                raw_text.is_empty() || raw_text == ZWSP
             }
             _ => false,
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -15,6 +15,7 @@
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::html_formatter::HtmlFormatter;
+use crate::dom::nodes::text_node::ZWSP;
 use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
 use crate::dom::to_html::ToHtml;
 use crate::dom::to_raw_text::ToRawText;
@@ -37,6 +38,9 @@ impl<S> DomNode<S>
 where
     S: UnicodeString,
 {
+    pub fn new_empty_text() -> DomNode<S> {
+        DomNode::Text(TextNode::new_zwsp())
+    }
     pub fn new_text(text: S) -> DomNode<S> {
         DomNode::Text(TextNode::from(text))
     }
@@ -131,7 +135,7 @@ where
     pub(crate) fn is_placeholder_text_node(&self) -> bool {
         match self {
             DomNode::Text(n) => {
-                n.data().len() == 1 && n.data().to_string() == "\u{200b}"
+                n.data().len() == 1 && n.data().to_string() == ZWSP
             }
             _ => false,
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -38,7 +38,7 @@ impl<S> DomNode<S>
 where
     S: UnicodeString,
 {
-    pub fn new_empty_text() -> DomNode<S> {
+    pub fn new_zwsp() -> DomNode<S> {
         DomNode::Text(TextNode::new_zwsp())
     }
     pub fn new_text(text: S) -> DomNode<S> {

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -43,6 +43,10 @@ where
     /// NOTE: Its handle() will be unset until you call set_handle() or
     /// append() it to another node.
     pub fn from(data: S) -> Self {
+        assert!(
+            !data.is_empty(),
+            "Can't create a TextNode with empty content"
+        );
         Self {
             data,
             handle: DomHandle::new_unset(),

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -23,6 +23,8 @@ use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::UnicodeString;
 
+pub const ZWSP: &str = "\u{200B}";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct TextNode<S>
 where
@@ -43,6 +45,13 @@ where
     pub fn from(data: S) -> Self {
         Self {
             data,
+            handle: DomHandle::new_unset(),
+        }
+    }
+
+    pub fn new_zwsp() -> Self {
+        Self {
+            data: ZWSP.into(),
             handle: DomHandle::new_unset(),
         }
     }
@@ -144,7 +153,7 @@ where
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
         let mut description = S::from("\"");
-        let text = &self.data.to_string().replace('\u{200b}', "~");
+        let text = &self.data.to_string().replace(ZWSP, "~");
         description.push(text.as_str());
         description.push('"');
         return self.tree_line(

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -17,6 +17,8 @@ use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 
 use widestring::{Utf16Str, Utf16String, Utf32Str, Utf32String};
 
+use crate::dom::nodes::text_node::ZWSP;
+
 /// The type of string being used inside a [Dom] instance. Must
 /// contain valid Unicode, and allow slicing by code unit positions.
 /// We implement this for String, Utf16String and Utf32String (from the
@@ -42,6 +44,8 @@ pub trait UnicodeString:
     type CodeUnit: Copy + From<u8> + PartialEq;
     type Slice: ToOwned<Owned = Self> + ?Sized;
 
+    fn new_zwsp() -> Self;
+
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String>;
 
     /// Convert this character to a code unit.
@@ -52,6 +56,10 @@ pub trait UnicodeString:
 impl UnicodeString for String {
     type CodeUnit = u8;
     type Slice = str;
+
+    fn new_zwsp() -> Self {
+        String::from(ZWSP)
+    }
 
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         String::from_utf8(v.into()).map_err(|e| e.to_string())
@@ -69,6 +77,10 @@ impl UnicodeString for Utf16String {
     type CodeUnit = u16;
     type Slice = Utf16Str;
 
+    fn new_zwsp() -> Self {
+        Utf16String::from_str(ZWSP)
+    }
+
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf16String::from_vec(v.into()).map_err(|e| e.to_string())
     }
@@ -85,6 +97,10 @@ impl UnicodeString for Utf32String {
     type CodeUnit = u32;
     type Slice = Utf32Str;
 
+    fn new_zwsp() -> Self {
+        Utf32String::from_str(ZWSP)
+    }
+
     fn from_vec(v: impl Into<Vec<Self::CodeUnit>>) -> Result<Self, String> {
         Utf32String::from_vec(v.into()).map_err(|e| e.to_string())
     }
@@ -92,7 +108,7 @@ impl UnicodeString for Utf32String {
     fn c_from_char(ch: char) -> Self::CodeUnit {
         let mut ret = Utf32String::new();
         ret.push(ch);
-        assert!(ret.len() == 1);
+        assert_eq!(ret.len(), 1);
         ret.into_vec()[0]
     }
 }

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -25,27 +25,27 @@ use crate::ComposerModel;
 fn creating_ordered_list_and_writing() {
     let mut model = cm("|");
     model.ordered_list();
-    assert_eq!(tx(&model), "<ol><li>|</li></ol>");
+    assert_eq!(tx(&model), "<ol><li>~|</li></ol>");
     replace_text(&mut model, "abcd");
-    assert_eq!(tx(&model), "<ol><li>abcd|</li></ol>");
+    assert_eq!(tx(&model), "<ol><li>~abcd|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<ol><li>abcd</li><li>~|</li></ol>");
+    assert_eq!(tx(&model), "<ol><li>~abcd</li><li>~|</li></ol>");
     replace_text(&mut model, "efgh");
-    assert_eq!(tx(&model), "<ol><li>abcd</li><li>~efgh|</li></ol>");
+    assert_eq!(tx(&model), "<ol><li>~abcd</li><li>~efgh|</li></ol>");
 }
 
 #[test]
 fn creating_unordered_list() {
     let mut model = cm("|");
     model.unordered_list();
-    assert_eq!(tx(&model), "<ul><li>|</li></ul>");
+    assert_eq!(tx(&model), "<ul><li>~|</li></ul>");
 }
 
 #[test]
 fn can_create_list_in_empty_model() {
     let mut model = ComposerModel::new();
     model.unordered_list();
-    assert_eq!(tx(&model), "<ul><li>|</li></ul>");
+    assert_eq!(tx(&model), "<ul><li>~|</li></ul>");
 }
 
 #[test]
@@ -60,11 +60,11 @@ fn removing_list_item() {
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.backspace();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[test]
@@ -92,21 +92,21 @@ fn backspacing_empty_second_list_item_into_whole_of_first_leaves_empty_item() {
 fn entering_with_entire_selection_in_one_node_deletes_list() {
     let mut model = cm("<ol><li>{abcd}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[test]
 fn entering_with_entire_selection_across_multiple_nodes_deletes_list() {
     let mut model = cm("<ol><li>{abcd</li><li>~}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[test]
 fn entering_with_entire_selection_with_formatting() {
     let mut model = cm("<ol><li><b>{abcd}|</b></li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn removing_list() {
     let mut model = cm("|");
     model.ordered_list();
     model.enter();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[test]
@@ -151,16 +151,16 @@ fn moving_list_item_content_out() {
 
 #[test]
 fn appending_new_list_to_previous() {
-    let mut model = cm("<ol><li>ab</li></ol>cd|");
+    let mut model = cm("<ol><li>~ab</li></ol>cd|");
     model.ordered_list();
-    assert_eq!(tx(&model), "<ol><li>ab</li><li>cd|</li></ol>");
+    assert_eq!(tx(&model), "<ol><li>~ab</li><li>~cd|</li></ol>");
 }
 
 #[test]
 fn creating_list_of_different_type_doesnt_merge() {
-    let mut model = cm("<ul><li>foo</li></ul>bar|");
+    let mut model = cm("<ul><li>~foo</li></ul>bar|");
     model.ordered_list();
-    assert_eq!(tx(&model), "<ul><li>foo</li></ul><ol><li>bar|</li></ol>");
+    assert_eq!(tx(&model), "<ul><li>~foo</li></ul><ol><li>~bar|</li></ol>");
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn creating_a_new_list_immediately_after_an_old_one_joins_them() {
     model.enter();
     model.replace_text(Utf16String::from_str("def"));
     model.unordered_list();
-    assert_eq!(tx(&model), "<ul><li>abc</li><li>~def|</li></ul>");
+    assert_eq!(tx(&model), "<ul><li>~abc</li><li>~def|</li></ul>");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -60,11 +60,11 @@ fn removing_list_item() {
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.backspace();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
 }
 
 #[test]
@@ -92,21 +92,21 @@ fn backspacing_empty_second_list_item_into_whole_of_first_leaves_empty_item() {
 fn entering_with_entire_selection_in_one_node_deletes_list() {
     let mut model = cm("<ol><li>{abcd}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
 }
 
 #[test]
 fn entering_with_entire_selection_across_multiple_nodes_deletes_list() {
     let mut model = cm("<ol><li>{abcd</li><li>~}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
 }
 
 #[test]
 fn entering_with_entire_selection_with_formatting() {
     let mut model = cm("<ol><li><b>{abcd}|</b></li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
 }
 
 #[test]
@@ -130,7 +130,17 @@ fn removing_list() {
     let mut model = cm("|");
     model.ordered_list();
     model.enter();
-    assert_eq!(tx(&model), "|~");
+    assert_eq!(tx(&model), "~|");
+}
+
+#[test]
+fn removing_list_then_typing() {
+    let mut model = cm("|");
+    model.ordered_list();
+    model.enter();
+    assert_eq!(tx(&model), "~|");
+    model.replace_text(utf16("Some text"));
+    assert_eq!(tx(&model), "Some text|");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -23,7 +23,7 @@ use crate::{
 
 #[test]
 fn pressing_enter_with_a_brand_new_model() {
-    let mut model: ComposerModel<Utf16String> = ComposerModel::new();
+    let mut model = ComposerModel::new();
     model.enter();
     assert_eq!(tx(&model), "<br />|");
 }

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -143,7 +143,8 @@ fn can_backspace_to_beginning_after_making_a_line() {
     model.enter();
     model.backspace();
     model.backspace();
-    assert_eq!(tx(&model), "|~");
+    // TODO: this might need to contain a ZWSP, but trying to make that happen breaks everything else
+    assert_eq!(tx(&model), "|");
 }
 
 #[ignore] // TODO: backspace_merges_empty_text_nodes

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -23,7 +23,7 @@ use crate::{
 
 #[test]
 fn pressing_enter_with_a_brand_new_model() {
-    let mut model = ComposerModel::new();
+    let mut model: ComposerModel<Utf16String> = ComposerModel::new();
     model.enter();
     assert_eq!(tx(&model), "<br />|");
 }
@@ -143,7 +143,7 @@ fn can_backspace_to_beginning_after_making_a_line() {
     model.enter();
     model.backspace();
     model.backspace();
-    assert_eq!(tx(&model), "|");
+    assert_eq!(tx(&model), "|~");
 }
 
 #[ignore] // TODO: backspace_merges_empty_text_nodes

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
@@ -36,7 +36,7 @@ class InterceptInputConnection(
     init {
         keyEventJob = processKeyEvents()
         // TODO: remove this once we have an initial menu state update
-        inputProcessor.processInput(EditorInputAction.InsertText(""))
+        inputProcessor.updateSelection(editable, 0, 0)
     }
 
     override fun getEditable(): Editable {


### PR DESCRIPTION
Any TextNode created should either be non-empty or contain a ZWSP.

I also tried to minimise the amount of empty text nodes added while replacing text, and tried replacing `\u{200B}` where possible with `ZWSP` constant.