### PR TITLE
Trigger iOS CI with label

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,13 +5,16 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [ labeled, synchronized, opened, reopened ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'iOS'))  
     runs-on: macos-12
 
     steps:


### PR DESCRIPTION
This change will only trigger the iOS workflow on pushes to main, or if the PR contains an iOS label