### PR TITLE
test: Move `#![cfg(test)]` on test module, rather than submodule

### DIFF
--- a/crates/wysiwyg/src/tests.rs
+++ b/crates/wysiwyg/src/tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(test)]
+
 pub mod test_characters;
 pub mod test_deleting;
 pub mod test_formatting;

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::{cm, tx};
 
 use crate::Location;

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::cm;
 use crate::tests::testutils_conversion::utf16;
 

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::tests::testutils_composer_model::{cm, tx};

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use std::collections::HashSet;
 
 use widestring::Utf16String;

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::{

--- a/crates/wysiwyg/src/tests/test_selection.rs
+++ b/crates/wysiwyg/src/tests/test_selection.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::{cm, tx};
 
 use crate::{InlineFormatType, Location, TextUpdate};

--- a/crates/wysiwyg/src/tests/test_to_raw_text.rs
+++ b/crates/wysiwyg/src/tests/test_to_raw_text.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::tests::testutils_composer_model::cm;

--- a/crates/wysiwyg/src/tests/test_to_tree.rs
+++ b/crates/wysiwyg/src/tests/test_to_tree.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::cm;
 use crate::ToTree;
 

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use crate::tests::testutils_composer_model::cm;
 
 use crate::dom::nodes::{DomNode, TextNode};

--- a/crates/wysiwyg/src/tests/testutils_composer_model.rs
+++ b/crates/wysiwyg/src/tests/testutils_composer_model.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::ComposerModel;

--- a/crates/wysiwyg/src/tests/testutils_conversion.rs
+++ b/crates/wysiwyg/src/tests/testutils_conversion.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 pub fn utf16(s: &str) -> Utf16String {

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
-
 use widestring::Utf16String;
 
 use crate::dom::nodes::DomNode;


### PR DESCRIPTION
Instead of having `#![cfg(test)]` on all test files, we can put it directly in the `src/tests.rs` module.