### PR TITLE
feat(wysiwyg): Add Markdown support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 name = "wysiwyg"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "html-escape",
  "html5ever",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,6 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 name = "wysiwyg"
 version = "0.1.0"
 dependencies = [
- "bitflags",
  "html-escape",
  "html5ever",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
@@ -398,9 +398,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec",
  "funty",
@@ -637,6 +637,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -1150,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d730d941cf471131c40a64cf2e8a595822009f51e64c05c5afdbc85af155857"
 dependencies = [
  "fs-err",
- "nom 6.2.1",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -1241,6 +1252,7 @@ dependencies = [
  "html-escape",
  "html5ever",
  "once_cell",
+ "pulldown-cmark",
  "speculoos",
  "widestring",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ opt-level = 'z'     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic
-debug = true # Enable debug symbols. For example, we can use `dwarfdump` to check crash traces.
+debug = false # Enable debug symbols. For example, we can use `dwarfdump` to check crash traces.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ opt-level = 'z'     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic
-debug = false # Enable debug symbols. For example, we can use `dwarfdump` to check crash traces.
+debug = true        # Enable debug symbols. For example, we can use `dwarfdump` to check crash traces.

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -19,7 +19,3 @@ widestring = "1.0.2"
 [dev-dependencies]
 speculoos = "0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }
-
-[features]
-default = ["to-markdown"]
-to-markdown = []

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -10,8 +10,6 @@ name = "wysiwyg"
 version = "0.1.0"
 rust-version = "1.60"
 
-[features]
-
 [dependencies]
 html-escape = "0.2.11"
 html5ever = "0.25.2"
@@ -20,3 +18,7 @@ widestring = "1.0.2"
 
 [dev-dependencies]
 speculoos = "0.9"
+
+[features]
+default = ["to-markdown"]
+to-markdown = []

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -19,6 +19,7 @@ widestring = "1.0.2"
 
 [dev-dependencies]
 speculoos = "0.9"
+pulldown-cmark = { version = "0.9.2", default-features = false }
 
 [features]
 default = ["to-markdown"]

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.1.0"
 rust-version = "1.60"
 
 [dependencies]
-bitflags = { version = "1.3.2", optional = true }
 html-escape = "0.2.11"
 html5ever = "0.25.2"
 once_cell = "1.13.0"
@@ -23,4 +22,4 @@ pulldown-cmark = { version = "0.9.2", default-features = false }
 
 [features]
 default = ["to-markdown"]
-to-markdown = ["dep:bitflags"]
+to-markdown = []

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 rust-version = "1.60"
 
 [dependencies]
+bitflags = { version = "1.3.2", optional = true }
 html-escape = "0.2.11"
 html5ever = "0.25.2"
 once_cell = "1.13.0"
@@ -21,4 +22,4 @@ speculoos = "0.9"
 
 [features]
 default = ["to-markdown"]
-to-markdown = []
+to-markdown = ["dep:bitflags"]

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -34,7 +34,6 @@ pub use find_result::FindResult;
 pub use range::DomLocation;
 pub use range::Range;
 pub use to_html::ToHtml;
-#[cfg(feature = "to-markdown")]
 pub use to_markdown::{MarkdownError, ToMarkdown};
 pub use to_raw_text::ToRawText;
 pub use to_tree::ToTree;

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -35,7 +35,7 @@ pub use range::DomLocation;
 pub use range::Range;
 pub use to_html::ToHtml;
 #[cfg(feature = "to-markdown")]
-pub use to_markdown::{Error as MarkdownError, ToMarkdown};
+pub use to_markdown::{MarkdownError, ToMarkdown};
 pub use to_raw_text::ToRawText;
 pub use to_tree::ToTree;
 pub use unicode_string::UnicodeString;

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -22,6 +22,7 @@ pub mod nodes;
 pub mod parser;
 pub mod range;
 pub mod to_html;
+pub mod to_markdown;
 pub mod to_raw_text;
 pub mod to_tree;
 pub mod unicode_string;
@@ -33,6 +34,8 @@ pub use find_result::FindResult;
 pub use range::DomLocation;
 pub use range::Range;
 pub use to_html::ToHtml;
+#[cfg(feature = "to-markdown")]
+pub use to_markdown::{Error as MarkdownError, ToMarkdown};
 pub use to_raw_text::ToRawText;
 pub use to_tree::ToTree;
 pub use unicode_string::UnicodeString;

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -16,6 +16,8 @@ use std::fmt::Display;
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
+#[cfg(feature = "to-markdown")]
+use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{
     find_range, to_raw_text::ToRawText, DomHandle, Range, ToTree, UnicodeString,
@@ -367,6 +369,16 @@ where
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
         self.document.to_tree_display(continuous_positions)
+    }
+}
+
+#[cfg(feature = "to-markdown")]
+impl<S> ToMarkdown<S> for Dom<S>
+where
+    S: UnicodeString,
+{
+    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+        self.document.fmt_markdown(buf)
     }
 }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -17,7 +17,7 @@ use std::fmt::Display;
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
 #[cfg(feature = "to-markdown")]
-use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
+use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{
     find_range, to_raw_text::ToRawText, DomHandle, Range, ToTree, UnicodeString,
@@ -377,8 +377,12 @@ impl<S> ToMarkdown<S> for Dom<S>
 where
     S: UnicodeString,
 {
-    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
-        self.document.fmt_markdown(buf)
+    fn fmt_markdown(
+        &self,
+        buffer: &mut S,
+        options: &MarkdownOptions,
+    ) -> Result<(), MarkdownError<S>> {
+        self.document.fmt_markdown(buffer, options)
     }
 }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -16,7 +16,6 @@ use std::fmt::Display;
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
-#[cfg(feature = "to-markdown")]
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{
@@ -372,7 +371,6 @@ where
     }
 }
 
-#[cfg(feature = "to-markdown")]
 impl<S> ToMarkdown<S> for Dom<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -394,34 +394,42 @@ where
 
             // Simple emphasis.
             Formatting(Italic) => {
-                buf.push("_");
+                // Many implementations have restricted intrawords
+                // simple emphasis to `*` to avoid unwanted emphasis
+                // in words containing internal underscores, like
+                // `foo_bar_baz`. We reckon it's good to follow this
+                // trend to avoid unexpected behaviours for our users.
+
+                buf.push("*");
 
                 for child in self.children.iter() {
                     child.fmt_markdown(buf)?;
                 }
 
-                buf.push("_");
+                buf.push("*");
             }
 
             // Strong emphasis.
             Formatting(Bold) => {
-                // `Formatting(Italic)` already uses `_` to represent
+                // `Formatting(Italic)` already uses `*` to represent
                 // a simple emphasis.
                 //
-                // We reckon it is better to use `*` to represent a
-                // strong emphasis instead of `_` so that
+                // We reckon it is better to use `_` to represent a
+                // strong emphasis instead of `*` so that
                 // `<em><strong>…</strong></em>` does _not_ produce
                 // `***…` or `___` which can be ambigiously
                 // interpreted by various Markdown compilers out
-                // there. Instead, it will produce `_**…**_`.
-                buf.push("**");
+                // there. Instead, it will produce `*__…__*`.
+                buf.push("__");
 
                 for child in self.children.iter() {
                     child.fmt_markdown(buf)?;
                 }
 
-                buf.push("**");
+                buf.push("__");
             }
+
+            Formatting(StrikeThrough) => {}
 
             _ => {
                 return Err(MarkdownError::UnknownContainerName(

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -576,7 +576,7 @@ where
                         buffer.push('.');
 
                         // Indentation will match the counter size.
-                        indentation += counter.len() + 1 /* `.` */;
+                        indentation += counter.len();
                     }
                     // It's an unordered list.
                     else {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -392,7 +392,28 @@ where
                 }
             }
 
+            // Simple emphasis.
+            Formatting(Italic) => {
+                buf.push("_");
+
+                for child in self.children.iter() {
+                    child.fmt_markdown(buf)?;
+                }
+
+                buf.push("_");
+            }
+
+            // Strong emphasis.
             Formatting(Bold) => {
+                // `Formatting(Italic)` already uses `_` to represent
+                // a simple emphasis.
+                //
+                // We reckon it is better to use `*` to represent a
+                // strong emphasis instead of `_` so that
+                // `<em><strong>…</strong></em>` does _not_ produce
+                // `***…` or `___` which can be ambigiously
+                // interpreted by various Markdown compilers out
+                // there. Instead, it will produce `_**…**_`.
                 buf.push("**");
 
                 for child in self.children.iter() {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -392,9 +392,54 @@ where
         use ContainerNodeKind::*;
         use InlineFormatType::*;
 
+        let mut options = *options;
+
+        match self.kind() {
+            Generic => {
+                fmt_children(self, buffer, &options)?;
+            }
+
+            // Simple emphasis.
+            Formatting(Italic) => {
+                fmt_italic(self, buffer, &options)?;
+            }
+
+            // Strong emphasis.
+            Formatting(Bold) => {
+                fmt_bold(self, buffer, &options)?;
+            }
+
+            Formatting(StrikeThrough) => {
+                fmt_strikethrough(self, buffer, &options)?;
+            }
+
+            Formatting(Underline) => {
+                fmt_underline(self, buffer, &options)?;
+            }
+
+            Formatting(InlineCode) => {
+                fmt_inline_code(self, buffer, &mut options)?;
+            }
+
+            Link(url) => {
+                fmt_link(self, buffer, &options, url)?;
+            }
+
+            List => {
+                fmt_list(self, buffer, &options)?;
+            }
+
+            ListItem => {
+                fmt_list_item(self, buffer, &options)?;
+            }
+        };
+
+        return Ok(());
+
         // `fmt_children` is a super basic loop over children to call
         // `fmt_markdown`, except that it inserts `\n` between block
         // nodes.
+        #[inline(always)]
         fn fmt_children<S>(
             this: &ContainerNode<S>,
             buffer: &mut S,
@@ -414,227 +459,296 @@ where
             Ok(())
         }
 
-        let mut options = *options;
+        #[inline(always)]
+        fn fmt_italic<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            // Many implementations have restricted intrawords
+            // simple emphasis to `*` to avoid unwanted emphasis
+            // in words containing internal underscores, like
+            // `foo_bar_baz`. We reckon it's good to follow this
+            // trend to avoid unexpected behaviours for our users.
 
-        match self.kind() {
-            Generic => {
-                fmt_children(self, buffer, &options)?;
-            }
+            buffer.push("*");
+            fmt_children(this, buffer, &options)?;
+            buffer.push("*");
 
-            // Simple emphasis.
-            Formatting(Italic) => {
-                // Many implementations have restricted intrawords
-                // simple emphasis to `*` to avoid unwanted emphasis
-                // in words containing internal underscores, like
-                // `foo_bar_baz`. We reckon it's good to follow this
-                // trend to avoid unexpected behaviours for our users.
+            Ok(())
+        }
 
-                buffer.push("*");
-                fmt_children(self, buffer, &options)?;
-                buffer.push("*");
-            }
+        #[inline(always)]
+        fn fmt_bold<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            // `Formatting(Italic)` already uses `*` to represent
+            // a simple emphasis.
+            //
+            // We reckon it is better to use `_` to represent a
+            // strong emphasis instead of `*` so that
+            // `<em><strong>…</strong></em>` does _not_ produce
+            // `***…***` or `___…___` which can be ambigiously
+            // interpreted by various Markdown compilers out
+            // there. Instead, it will produce `*__…__*`.
 
-            // Strong emphasis.
-            Formatting(Bold) => {
-                // `Formatting(Italic)` already uses `*` to represent
-                // a simple emphasis.
-                //
-                // We reckon it is better to use `_` to represent a
-                // strong emphasis instead of `*` so that
-                // `<em><strong>…</strong></em>` does _not_ produce
-                // `***…***` or `___…___` which can be ambigiously
-                // interpreted by various Markdown compilers out
-                // there. Instead, it will produce `*__…__*`.
+            buffer.push("__");
+            fmt_children(this, buffer, &options)?;
+            buffer.push("__");
 
-                buffer.push("__");
-                fmt_children(self, buffer, &options)?;
-                buffer.push("__");
-            }
+            Ok(())
+        }
 
-            Formatting(StrikeThrough) => {
-                // Strikethrough is represented by a pair of one or
-                // two `~`. We reckon using two `~` will avoid
-                // ambiguous behaviours for users that manipulate
-                // filesystem paths, or with Markdown compilers that
-                // do not support this format extension.
+        #[inline(always)]
+        fn fmt_strikethrough<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            // Strikethrough is represented by a pair of one or
+            // two `~`. We reckon using two `~` will avoid
+            // ambiguous behaviours for users that manipulate
+            // filesystem paths, or with Markdown compilers that
+            // do not support this format extension.
 
-                buffer.push("~~");
-                fmt_children(self, buffer, &options)?;
-                buffer.push("~~");
-            }
+            buffer.push("~~");
+            fmt_children(this, buffer, &options)?;
+            buffer.push("~~");
 
-            Formatting(Underline) => {
-                // Underline format is absent from Markdown. Let's
-                // ignore it!
+            Ok(())
+        }
 
-                fmt_children(self, buffer, &options)?;
-            }
+        #[inline(always)]
+        fn fmt_underline<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            // Underline format is absent from Markdown. Let's
+            // ignore it!
 
-            Formatting(InlineCode) => {
-                // An inline code usually is usually delimited by an
-                // opening and a closing single backtick. However, if
-                // the inline code string contains a backtick, it is
-                // preferable to use an opening and a closing double
-                // backticks to delimit the inline code string.
-                //
-                // In addition to this subtlety, we add a space after
-                // and before the opening and closing double backticks
-                // to allow an inline code string to start by a
-                // backtick. Those spaces are removed during
-                // normalization.
+            fmt_children(this, buffer, &options)?;
 
-                buffer.push("`` ");
+            Ok(())
+        }
 
-                options.insert(MarkdownOptions::IGNORE_LINE_BREAK);
-                fmt_children(self, buffer, &options)?;
+        #[inline(always)]
+        fn fmt_inline_code<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &mut MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            // An inline code usually is usually delimited by an
+            // opening and a closing single backtick. However, if
+            // the inline code string contains a backtick, it is
+            // preferable to use an opening and a closing double
+            // backticks to delimit the inline code string.
+            //
+            // In addition to this subtlety, we add a space after
+            // and before the opening and closing double backticks
+            // to allow an inline code string to start by a
+            // backtick. Those spaces are removed during
+            // normalization.
 
-                buffer.push(" ``");
-            }
+            buffer.push("`` ");
 
-            Link(url) => {
-                buffer.push('[');
+            options.insert(MarkdownOptions::IGNORE_LINE_BREAK);
+            fmt_children(this, buffer, &options)?;
 
-                fmt_children(self, buffer, &options)?;
+            buffer.push(" ``");
 
-                // A link destination can be delimited by `<` and
-                // `>`.
-                //
-                // The link URL can contain `<`, `>`, `(` and `)` if
-                // they are escaped. Parenthesis, if unbalanced, can
-                // not be escaped, but we are playing safety and
-                // simplicity.
+            Ok(())
+        }
 
-                buffer.push("](<");
-                buffer.push(
-                    url.to_string()
-                        .replace('<', "\\<")
-                        .replace('>', "\\>")
-                        .replace('(', "\\(")
-                        .replace(')', "\\)")
-                        .as_str(),
-                );
-                buffer.push(">)");
-            }
+        #[inline(always)]
+        fn fmt_link<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+            url: &S,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            buffer.push('[');
 
-            List => {
-                let list_type = self.name();
-                let ordered_list_name = "ol";
-                let expected_list_item_name = &S::from("li");
-                let number_of_children = self.children.len();
-                let mut ordered_list_counter = 0i32;
+            fmt_children(this, buffer, &options)?;
 
-                for (nth, child) in self.children.iter().enumerate() {
-                    // Verify the list item is correct.
-                    let child = match child {
-                        // Valid item.
-                        DomNode::Container(
-                            child @ Self {
-                                name,
-                                kind: ListItem,
-                                ..
-                            },
-                        ) if name == expected_list_item_name => child,
+            // A link destination can be delimited by `<` and
+            // `>`.
+            //
+            // The link URL can contain `<`, `>`, `(` and `)` if
+            // they are escaped. Parenthesis, if unbalanced, can
+            // not be escaped, but we are playing safety and
+            // simplicity.
 
-                        // Item to ignore.
-                        DomNode::Text(t) if t.is_blank() => {
-                            continue;
-                        }
+            buffer.push("](<");
+            buffer.push(
+                url.to_string()
+                    .replace('<', "\\<")
+                    .replace('>', "\\>")
+                    .replace('(', "\\(")
+                    .replace(')', "\\)")
+                    .as_str(),
+            );
+            buffer.push(">)");
 
-                        // All the following are invalid items.
-                        DomNode::Container(Self {
-                            name: child_name, ..
-                        }) => {
-                            return Err(MarkdownError::InvalidListItem(Some(
-                                child_name.to_owned(),
-                            )))
-                        }
+            Ok(())
+        }
 
-                        DomNode::LineBreak(line_break) => {
-                            return Err(MarkdownError::InvalidListItem(Some(
-                                line_break.name(),
-                            )))
-                        }
+        #[inline(always)]
+        fn fmt_list<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            let list_type = this.name();
+            let ordered_list_name = "ol";
+            let expected_list_item_name = &S::from("li");
+            let number_of_children = this.children.len();
+            let mut ordered_list_counter = 0i32;
 
-                        DomNode::Text(_) => {
-                            return Err(MarkdownError::InvalidListItem(None))
-                        }
+            for (nth, child) in this.children.iter().enumerate() {
+                // Verify the list item is correct.
+                let child = match child {
+                    // Valid item.
+                    DomNode::Container(
+                        child @ ContainerNode {
+                            name,
+                            kind: ListItem,
+                            ..
+                        },
+                    ) if name == expected_list_item_name => child,
+
+                    // Item to ignore.
+                    DomNode::Text(t) if t.is_blank() => {
+                        continue;
+                    }
+
+                    // All the following are invalid items.
+                    DomNode::Container(ContainerNode {
+                        name: child_name,
+                        ..
+                    }) => {
+                        return Err(MarkdownError::InvalidListItem(Some(
+                            child_name.to_owned(),
+                        )))
+                    }
+
+                    DomNode::LineBreak(line_break) => {
+                        return Err(MarkdownError::InvalidListItem(Some(
+                            line_break.name(),
+                        )))
+                    }
+
+                    DomNode::Text(_) => {
+                        return Err(MarkdownError::InvalidListItem(None))
+                    }
+                };
+
+                // What's the current indentation, for this specific list only.
+                let mut indentation = 0;
+
+                // It's an ordered list.
+                if list_type == ordered_list_name {
+                    // Update the counter.
+                    ordered_list_counter += 1;
+
+                    // Generate something like `1.` (arabic numbers only,
+                    // as requested by the specification).
+                    let counter = ordered_list_counter.to_string();
+
+                    buffer.push(counter.as_str());
+                    buffer.push('.');
+
+                    // Indentation will match the counter size.
+                    indentation += counter.len();
+                }
+                // It's an unordered list.
+                else {
+                    // Generate something like `*`.
+                    buffer.push('*');
+
+                    // Indentation will match the counter size.
+                    indentation += 1;
+                }
+
+                // Insert a space between the counter and the item's content.
+                buffer.push(' ');
+
+                // And update the indentation.
+                indentation += 1;
+
+                {
+                    // Let's create a new buffer for the child formatting.
+                    let mut child_buffer = S::default();
+                    child.fmt_markdown(&mut child_buffer, &options)?;
+
+                    // Generate the indentation of form `\n` followed by
+                    // $x$ spaces where $x$ is `indentation`.
+                    let indentation = {
+                        let spaces = " ".repeat(indentation);
+                        let mut indentation =
+                            String::with_capacity(1 /* `\n` */ + indentation);
+                        indentation.push('\n');
+                        indentation.push_str(&spaces);
+
+                        indentation
                     };
 
-                    // What's the current indentation, for this specific list only.
-                    let mut indentation = 0;
+                    // Insert the child's buffer after `\n`s have been
+                    // replaced by `\n` followed by spaces for indentation.
+                    buffer.push(
+                        child_buffer
+                            .to_string()
+                            .replace('\n', &indentation)
+                            .as_str(),
+                    );
+                }
 
-                    // It's an ordered list.
-                    if list_type == ordered_list_name {
-                        // Update the counter.
-                        ordered_list_counter += 1;
+                let is_last = nth == number_of_children - 1;
 
-                        // Generate something like `1.` (arabic numbers only,
-                        // as requested by the specification).
-                        let counter = ordered_list_counter.to_string();
-
-                        buffer.push(counter.as_str());
-                        buffer.push('.');
-
-                        // Indentation will match the counter size.
-                        indentation += counter.len();
-                    }
-                    // It's an unordered list.
-                    else {
-                        // Generate something like `*`.
-                        buffer.push('*');
-
-                        // Indentation will match the counter size.
-                        indentation += 1;
-                    }
-
-                    // Insert a space between the counter and the item's content.
-                    buffer.push(' ');
-
-                    // And update the indentation.
-                    indentation += 1;
-
-                    {
-                        // Let's create a new buffer for the child formatting.
-                        let mut child_buffer = S::default();
-                        child.fmt_markdown(&mut child_buffer, &options)?;
-
-                        // Generate the indentation of form `\n` followed by
-                        // $x$ spaces where $x$ is `indentation`.
-                        let indentation = {
-                            let spaces = " ".repeat(indentation);
-                            let mut indentation = String::with_capacity(
-                                1 /* `\n` */ + indentation,
-                            );
-                            indentation.push('\n');
-                            indentation.push_str(&spaces);
-
-                            indentation
-                        };
-
-                        // Insert the child's buffer after `\n`s have been
-                        // replaced by `\n` followed by spaces for indentation.
-                        buffer.push(
-                            child_buffer
-                                .to_string()
-                                .replace('\n', &indentation)
-                                .as_str(),
-                        );
-                    }
-
-                    let is_last = nth == number_of_children - 1;
-
-                    if !is_last {
-                        buffer.push('\n');
-                    }
+                if !is_last {
+                    buffer.push('\n');
                 }
             }
 
-            ListItem => {
-                fmt_children(self, buffer, &options)?;
-            }
-        };
+            Ok(())
+        }
 
-        Ok(())
+        #[inline(always)]
+        fn fmt_list_item<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            fmt_children(this, buffer, &options)?;
+
+            Ok(())
+        }
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -446,6 +446,15 @@ where
                 buf.push("~~");
             }
 
+            Formatting(Underline) => {
+                // Underline format is absent from Markdown. Let's
+                // ignore it!
+
+                for child in self.children.iter() {
+                    child.fmt_markdown(buf)?;
+                }
+            }
+
             _ => {
                 return Err(MarkdownError::UnknownContainerName(
                     self.name().to_owned(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -394,7 +394,7 @@ where
         use ContainerNodeKind::*;
         use InlineFormatType::*;
 
-        // `fmt_children` is super basic loop over children to call
+        // `fmt_children` is a super basic loop over children to call
         // `fmt_markdown`, except that it inserts `\n` between block
         // nodes.
         fn fmt_children<S>(
@@ -417,7 +417,6 @@ where
         }
 
         let mut options = *options;
-        options.insert(MarkdownOptions::IN_A_CONTAINER);
 
         match self.kind() {
             Generic => {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -16,7 +16,6 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::dom_node::DomNode;
 use crate::dom::to_html::ToHtml;
-#[cfg(feature = "to-markdown")]
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
@@ -381,7 +380,6 @@ where
     }
 }
 
-#[cfg(feature = "to-markdown")]
 impl<S> ToMarkdown<S> for ContainerNode<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -382,11 +382,24 @@ where
     S: UnicodeString,
 {
     fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+        use ContainerNodeKind::*;
+        use InlineFormatType::*;
+
         match self.kind() {
-            ContainerNodeKind::Generic => {
+            Generic => {
                 for child in self.children.iter() {
                     child.fmt_markdown(buf)?;
                 }
+            }
+
+            Formatting(Bold) => {
+                buf.push("**");
+
+                for child in self.children.iter() {
+                    child.fmt_markdown(buf)?;
+                }
+
+                buf.push("**");
             }
 
             _ => {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -460,7 +460,19 @@ where
             }
 
             Formatting(InlineCode) => {
-                buffer.push('`');
+                // An inline code usually is usually delimited by an
+                // opening and a closing single backtick. However, if
+                // the inline code string contains a backtick, it is
+                // preferable to use an opening and a closing double
+                // backticks to delimit the inline code string.
+                //
+                // In addition to this subtlety, we add a space after
+                // and before the opening and closing double backticks
+                // to allow an inline code string to start by a
+                // backtick. Those spaces are removed during
+                // normalization.
+
+                buffer.push("`` ");
 
                 let mut options = *options;
                 options.insert(MarkdownOptions::IGNORE_LINE_BREAK);
@@ -469,7 +481,7 @@ where
                     child.fmt_markdown(buffer, &options)?;
                 }
 
-                buffer.push('`');
+                buffer.push(" ``");
             }
 
             _ => {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -484,8 +484,19 @@ where
                 buffer.push(" ``");
             }
 
+            Link(url) => {
+                buffer.push('[');
+
+                for child in self.children.iter() {
+                    child.fmt_markdown(buffer, &options)?;
+                }
+
+                buffer.push("](");
+                buffer.push(url.clone());
+                buffer.push(')');
+            }
             _ => {
-                return Err(MarkdownError::UnknownContainerName(
+                return Err(MarkdownError::UnknownContainerNodeName(
                     self.name().to_owned(),
                 ))
             }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -417,9 +417,10 @@ where
                 // We reckon it is better to use `_` to represent a
                 // strong emphasis instead of `*` so that
                 // `<em><strong>…</strong></em>` does _not_ produce
-                // `***…` or `___` which can be ambigiously
+                // `***…***` or `___…___` which can be ambigiously
                 // interpreted by various Markdown compilers out
                 // there. Instead, it will produce `*__…__*`.
+
                 buf.push("__");
 
                 for child in self.children.iter() {
@@ -429,7 +430,21 @@ where
                 buf.push("__");
             }
 
-            Formatting(StrikeThrough) => {}
+            Formatting(StrikeThrough) => {
+                // Strikethrough is represented by a pair of one or
+                // two `~`. We reckon using two `~` will avoid
+                // ambiguous behaviours for users that manipulate
+                // filesystem paths, or with Markdown compilers that
+                // do not support this format extension.
+
+                buf.push("~~");
+
+                for child in self.children.iter() {
+                    child.fmt_markdown(buf)?;
+                }
+
+                buf.push("~~");
+            }
 
             _ => {
                 return Err(MarkdownError::UnknownContainerName(

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -16,6 +16,8 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::dom_node::DomNode;
 use crate::dom::to_html::ToHtml;
+#[cfg(feature = "to-markdown")]
+use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
@@ -371,6 +373,30 @@ where
             tree_part.push(child.to_tree_display(new_positions));
         }
         tree_part
+    }
+}
+
+#[cfg(feature = "to-markdown")]
+impl<S> ToMarkdown<S> for ContainerNode<S>
+where
+    S: UnicodeString,
+{
+    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+        match self.kind() {
+            ContainerNodeKind::Generic => {
+                for child in self.children.iter() {
+                    child.fmt_markdown(buf)?;
+                }
+            }
+
+            _ => {
+                return Err(MarkdownError::UnknownContainerName(
+                    self.name().to_owned(),
+                ))
+            }
+        };
+
+        Ok(())
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -488,12 +488,27 @@ where
                 buffer.push('[');
 
                 for child in self.children.iter() {
-                    child.fmt_markdown(buffer, &options)?;
+                    child.fmt_markdown(buffer, options)?;
                 }
 
-                buffer.push("](");
-                buffer.push(url.clone());
-                buffer.push(')');
+                // A link destination can be delimited by `<` and
+                // `>`.
+                //
+                // The link URL can contain `<`, `>`, `(` and `)` if
+                // they are escaped. Parenthesis, if unbalanced, can
+                // not be escaped, but we are playing safety and
+                // simplicity.
+
+                buffer.push("](<");
+                buffer.push(
+                    url.to_string()
+                        .replace('<', "\\<")
+                        .replace('>', "\\>")
+                        .replace('(', "\\(")
+                        .replace(')', "\\)")
+                        .as_str(),
+                );
+                buffer.push(">)");
             }
             _ => {
                 return Err(MarkdownError::UnknownContainerNodeName(

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -538,6 +538,11 @@ where
                             },
                         ) if name == expected_list_item_name => child,
 
+                        // Item to ignore.
+                        DomNode::Text(t) if t.is_blank() => {
+                            continue;
+                        }
+
                         // All the following are invalid items.
                         DomNode::Container(Self {
                             name: child_name, ..

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -16,6 +16,8 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
 use crate::dom::to_html::ToHtml;
+#[cfg(feature = "to-markdown")]
+use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::UnicodeStrExt;
@@ -191,6 +193,20 @@ where
             DomNode::Container(n) => n.to_tree_display(continuous_positions),
             DomNode::LineBreak(n) => n.to_tree_display(continuous_positions),
             DomNode::Text(n) => n.to_tree_display(continuous_positions),
+        }
+    }
+}
+
+#[cfg(feature = "to-markdown")]
+impl<S> ToMarkdown<S> for DomNode<S>
+where
+    S: UnicodeString,
+{
+    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+        match self {
+            DomNode::Container(container) => container.fmt_markdown(buf),
+            DomNode::Text(text) => text.fmt_markdown(buf),
+            DomNode::LineBreak(node) => node.fmt_markdown(buf),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -17,7 +17,7 @@ use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
 use crate::dom::to_html::ToHtml;
 #[cfg(feature = "to-markdown")]
-use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
+use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::UnicodeStrExt;
@@ -202,11 +202,17 @@ impl<S> ToMarkdown<S> for DomNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+    fn fmt_markdown(
+        &self,
+        buffer: &mut S,
+        options: &MarkdownOptions,
+    ) -> Result<(), MarkdownError<S>> {
         match self {
-            DomNode::Container(container) => container.fmt_markdown(buf),
-            DomNode::Text(text) => text.fmt_markdown(buf),
-            DomNode::LineBreak(node) => node.fmt_markdown(buf),
+            DomNode::Container(container) => {
+                container.fmt_markdown(buffer, options)
+            }
+            DomNode::Text(text) => text.fmt_markdown(buffer, options),
+            DomNode::LineBreak(node) => node.fmt_markdown(buffer, options),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -16,7 +16,6 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::{ContainerNode, LineBreakNode, TextNode};
 use crate::dom::to_html::ToHtml;
-#[cfg(feature = "to-markdown")]
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
@@ -205,7 +204,6 @@ where
     }
 }
 
-#[cfg(feature = "to-markdown")]
 impl<S> ToMarkdown<S> for DomNode<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -145,6 +145,14 @@ where
             _ => false,
         }
     }
+
+    pub(crate) fn is_block_node(&self) -> bool {
+        matches!(self, Self::Container(container) if container.is_block_node())
+    }
+
+    pub(crate) fn is_inline_node(&self) -> bool {
+        !self.is_block_node()
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -15,7 +15,6 @@
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::ToHtml;
-#[cfg(feature = "to-markdown")]
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
@@ -109,7 +108,6 @@ where
     }
 }
 
-#[cfg(feature = "to-markdown")]
 impl<S> ToMarkdown<S> for LineBreakNode<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -16,14 +16,14 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::ToHtml;
 #[cfg(feature = "to-markdown")]
-use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
+use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
 use std::marker::PhantomData;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LineBreakNode<S>
 where
     S: UnicodeString,
@@ -114,28 +114,37 @@ impl<S> ToMarkdown<S> for LineBreakNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
-        // A line break is a `\n` in Markdown. Two or more line breaks
-        // usually generate a new block (i.e. a new paragraph). To
-        // avoid that, we can prefix `\n` by a backslash. Thus:
-        //
-        // ```html
-        // abc<br />def
-        //
-        // ghi<br /><br />jkl
-        // ```
-        //
-        // maps to:
-        //
-        // ```md
-        // abc\
-        // def
-        //
-        // ghi\
-        // \
-        // jkl
-        // ```
-        buf.push("\\\n");
+    fn fmt_markdown(
+        &self,
+        buffer: &mut S,
+        options: &MarkdownOptions,
+    ) -> Result<(), MarkdownError<S>> {
+        if options.contains(MarkdownOptions::IGNORE_LINE_BREAK) {
+            // Replace the line break by a single space.
+            buffer.push(' ');
+        } else {
+            // A line break is a `\n` in Markdown. Two or more line breaks
+            // usually generate a new block (i.e. a new paragraph). To
+            // avoid that, we can prefix `\n` by a backslash. Thus:
+            //
+            // ```html
+            // abc<br />def
+            //
+            // ghi<br /><br />jkl
+            // ```
+            //
+            // maps to:
+            //
+            // ```md
+            // abc\
+            // def
+            //
+            // ghi\
+            // \
+            // jkl
+            // ```
+            buffer.push("\\\n");
+        }
 
         Ok(())
     }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 use crate::composer_model::example_format::SelectionWriter;
-use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
-use html_escape;
-
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::ToHtml;
+#[cfg(feature = "to-markdown")]
+use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
+use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
+use html_escape;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TextNode<S>
@@ -119,5 +120,17 @@ where
             self.handle.raw().len(),
             continuous_positions,
         );
+    }
+}
+
+#[cfg(feature = "to-markdown")]
+impl<S> ToMarkdown<S> for TextNode<S>
+where
+    S: UnicodeString,
+{
+    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
+        buf.push(self.data.to_owned());
+
+        Ok(())
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -15,7 +15,6 @@
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::ToHtml;
-#[cfg(feature = "to-markdown")]
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
@@ -129,7 +128,6 @@ where
     }
 }
 
-#[cfg(feature = "to-markdown")]
 impl<S> ToMarkdown<S> for TextNode<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -19,7 +19,7 @@ use crate::dom::to_html::ToHtml;
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
-use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
+use crate::dom::unicode_string::{UnicodeStr, UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
 use html_escape;
 
@@ -61,6 +61,12 @@ where
 
     pub fn set_handle(&mut self, handle: DomHandle) {
         self.handle = handle;
+    }
+
+    pub fn is_blank(&self) -> bool {
+        self.data
+            .chars()
+            .all(|c| matches!(c, ' ' | '\x09'..='\x0d'))
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -16,7 +16,7 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::ToHtml;
 #[cfg(feature = "to-markdown")]
-use crate::dom::to_markdown::{Error as MarkdownError, ToMarkdown};
+use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
@@ -128,8 +128,12 @@ impl<S> ToMarkdown<S> for TextNode<S>
 where
     S: UnicodeString,
 {
-    fn fmt_markdown(&self, buf: &mut S) -> Result<(), MarkdownError<S>> {
-        buf.push(self.data.to_owned());
+    fn fmt_markdown(
+        &self,
+        buffer: &mut S,
+        _options: &MarkdownOptions,
+    ) -> Result<(), MarkdownError<S>> {
+        buffer.push(self.data.to_owned());
 
         Ok(())
     }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -21,7 +21,7 @@ pub enum MarkdownError<S>
 where
     S: UnicodeString,
 {
-    UnknownContainerName(<S::Str as ToOwned>::Owned),
+    UnknownContainerNodeName(<S::Str as ToOwned>::Owned),
 }
 
 impl<S> Error for MarkdownError<S> where S: UnicodeString {}
@@ -32,8 +32,8 @@ where
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnknownContainerName(name) => {
-                write!(formatter, "Unknown container name: `{:?}`", name)
+            Self::UnknownContainerNodeName(name) => {
+                write!(formatter, "Unknown container node name: `{:?}`", name)
             }
         }
     }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -21,7 +21,7 @@ pub enum MarkdownError<S>
 where
     S: UnicodeString,
 {
-    InvalidListItem(Option<<S::Str as ToOwned>::Owned>),
+    InvalidListItem(Option<S>),
 }
 
 impl<S> Error for MarkdownError<S> where S: UnicodeString {}
@@ -50,15 +50,16 @@ where
     ) -> Result<(), MarkdownError<S>>;
 
     fn to_markdown(&self) -> Result<S, MarkdownError<S>> {
-        let mut buf = S::default();
-        self.fmt_markdown(&mut buf, &MarkdownOptions::empty())?;
+        let mut buffer = S::default();
+        self.fmt_markdown(&mut buffer, &MarkdownOptions::empty())?;
 
-        Ok(buf)
+        Ok(buffer)
     }
 }
 
 bitflags! {
     pub struct MarkdownOptions: u8 {
         const IGNORE_LINE_BREAK = 0b0001;
+        const IN_A_CONTAINER = 0b0010;
     }
 }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -21,7 +21,7 @@ pub enum MarkdownError<S>
 where
     S: UnicodeString,
 {
-    UnknownContainerNodeName(<S::Str as ToOwned>::Owned),
+    InvalidListItem(Option<<S::Str as ToOwned>::Owned>),
 }
 
 impl<S> Error for MarkdownError<S> where S: UnicodeString {}
@@ -32,9 +32,9 @@ where
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnknownContainerNodeName(name) => {
-                write!(formatter, "Unknown container node name: `{:?}`", name)
-            }
+            Self::InvalidListItem(Some(node_name)) => write!(formatter, "A list expects a list item as immediate child, received `{node_name}`"),
+
+            Self::InvalidListItem(None) => write!(formatter, "A list node expects a list item node as immediate child")
         }
     }
 }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::UnicodeString;
-use bitflags::bitflags;
 use std::{error::Error, fmt};
 
 #[derive(Debug)]
@@ -57,8 +56,25 @@ where
     }
 }
 
-bitflags! {
-    pub struct MarkdownOptions: u8 {
-        const IGNORE_LINE_BREAK = 0b0001;
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MarkdownOptions {
+    bits: u8,
+}
+
+impl MarkdownOptions {
+    pub const IGNORE_LINE_BREAK: Self = Self { bits: 0b0001 };
+
+    pub const fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    /// Returns `true` if all of the flags in `other` are contained within `self`.
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    /// Inserts the specified flags in-place.
+    pub fn insert(&mut self, other: Self) {
+        self.bits |= other.bits;
     }
 }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -60,6 +60,5 @@ where
 bitflags! {
     pub struct MarkdownOptions: u8 {
         const IGNORE_LINE_BREAK = 0b0001;
-        const IN_A_CONTAINER = 0b0010;
     }
 }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -13,17 +13,20 @@
 // limitations under the License.
 
 use super::UnicodeString;
-use std::fmt;
+use bitflags::bitflags;
+use std::{error::Error, fmt};
 
 #[derive(Debug)]
-pub enum Error<S>
+pub enum MarkdownError<S>
 where
     S: UnicodeString,
 {
     UnknownContainerName(<S::Str as ToOwned>::Owned),
 }
 
-impl<S> fmt::Display for Error<S>
+impl<S> Error for MarkdownError<S> where S: UnicodeString {}
+
+impl<S> fmt::Display for MarkdownError<S>
 where
     S: UnicodeString,
 {
@@ -40,12 +43,22 @@ pub trait ToMarkdown<S>
 where
     S: UnicodeString,
 {
-    fn fmt_markdown(&self, buf: &mut S) -> Result<(), Error<S>>;
+    fn fmt_markdown(
+        &self,
+        buffer: &mut S,
+        options: &MarkdownOptions,
+    ) -> Result<(), MarkdownError<S>>;
 
-    fn to_markdown(&self) -> Result<S, Error<S>> {
+    fn to_markdown(&self) -> Result<S, MarkdownError<S>> {
         let mut buf = S::default();
-        self.fmt_markdown(&mut buf)?;
+        self.fmt_markdown(&mut buf, &MarkdownOptions::empty())?;
 
         Ok(buf)
+    }
+}
+
+bitflags! {
+    pub struct MarkdownOptions: u8 {
+        const IGNORE_LINE_BREAK = 0b0001;
     }
 }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UnicodeString;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error<S>
+where
+    S: UnicodeString,
+{
+    UnknownContainerName(<S::Str as ToOwned>::Owned),
+}
+
+impl<S> fmt::Display for Error<S>
+where
+    S: UnicodeString,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownContainerName(name) => {
+                write!(formatter, "Unknown container name: `{:?}`", name)
+            }
+        }
+    }
+}
+
+pub trait ToMarkdown<S>
+where
+    S: UnicodeString,
+{
+    fn fmt_markdown(&self, buf: &mut S) -> Result<(), Error<S>>;
+
+    fn to_markdown(&self) -> Result<S, Error<S>> {
+        let mut buf = S::default();
+        self.fmt_markdown(&mut buf)?;
+
+        Ok(buf)
+    }
+}

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+use std::fmt;
 use std::iter;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 
@@ -23,8 +23,8 @@ use widestring::{Utf16Str, Utf16String, Utf32Str, Utf32String};
 /// widestring crate).
 pub trait UnicodeString:
     Clone
-    + std::fmt::Debug
-    + std::fmt::Display
+    + fmt::Debug
+    + fmt::Display
     + Default
     + PartialEq
     + AsRef<[Self::CodeUnit]>
@@ -46,7 +46,8 @@ pub trait UnicodeString:
 }
 
 pub trait UnicodeStr:
-    std::fmt::Display
+    fmt::Display
+    + fmt::Debug
     + PartialEq
     + PartialEq<str>
     + AsRef<[Self::CodeUnit]>

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -35,7 +35,6 @@ pub use crate::dom::ToHtml;
 pub use crate::dom::ToRawText;
 pub use crate::dom::ToTree;
 pub use crate::dom::UnicodeString;
-#[cfg(feature = "to-markdown")]
 pub use crate::dom::{MarkdownError, ToMarkdown};
 pub use crate::format_type::InlineFormatType;
 pub use crate::list_type::ListType;

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -35,6 +35,8 @@ pub use crate::dom::ToHtml;
 pub use crate::dom::ToRawText;
 pub use crate::dom::ToTree;
 pub use crate::dom::UnicodeString;
+#[cfg(feature = "to-markdown")]
+pub use crate::dom::{MarkdownError, ToMarkdown};
 pub use crate::format_type::InlineFormatType;
 pub use crate::list_type::ListType;
 pub use crate::location::Location;

--- a/crates/wysiwyg/src/tests.rs
+++ b/crates/wysiwyg/src/tests.rs
@@ -23,7 +23,6 @@ pub mod test_menu_state;
 pub mod test_paragraphs;
 pub mod test_replace_all_html;
 pub mod test_selection;
-#[cfg(feature = "to-markdown")]
 pub mod test_to_markdown;
 pub mod test_to_raw_text;
 pub mod test_to_tree;

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -40,43 +40,46 @@ def"#,
 
 #[test]
 fn test_with_italic() {
-    assert_eq!(md("<em>abc</em>|"), "_abc_");
-    assert_eq!(md("abc <em>def</em> ghi|"), "abc _def_ ghi");
-    assert_eq!(md("abc<em> def </em>ghi|"), "abc_ def _ghi");
+    assert_eq!(md("<em>abc</em>|"), "*abc*");
+    // Internal emphasis.
+    assert_eq!(md("abc<em>def</em>ghi|"), "abc*def*ghi");
+    assert_eq!(md("abc <em>def</em> ghi|"), "abc *def* ghi");
+    assert_eq!(md("abc<em> def </em>ghi|"), "abc* def *ghi");
     assert_eq!(
         md("abc <em>line1<br />line2<br /><br />line3</em> def|"),
-        r#"abc _line1\
+        r#"abc *line1\
 line2\
 \
-line3_ def"#,
+line3* def"#,
     );
 }
 
 #[test]
 fn test_with_bold() {
-    assert_eq!(md("<strong>abc</strong>|"), "**abc**");
-    assert_eq!(md("abc <strong>def</strong> ghi|"), "abc **def** ghi");
-    assert_eq!(md("abc<strong> def </strong>ghi|"), "abc** def **ghi");
+    assert_eq!(md("<strong>abc</strong>|"), "__abc__");
+    assert_eq!(md("abc<strong>def</strong>ghi|"), "abc__def__ghi");
+    assert_eq!(md("abc <strong>def</strong> ghi|"), "abc __def__ ghi");
+    assert_eq!(md("abc<strong> def </strong>ghi|"), "abc__ def __ghi");
     assert_eq!(
         md("abc <strong>line1<br />line2<br /><br />line3</strong> def|"),
-        r#"abc **line1\
+        r#"abc __line1\
 line2\
 \
-line3** def"#,
+line3__ def"#,
     );
 }
 
 #[test]
 fn test_with_italic_and_bold() {
-    assert_eq!(md("<em><strong>abc</strong></em>|"), "_**abc**_");
+    assert_eq!(md("<em><strong>abc</strong></em>|"), "*__abc__*");
     assert_eq!(
         md("<em>abc <strong>def</strong></em> ghi|"),
-        "_abc **def**_ ghi"
+        "*abc __def__* ghi"
     );
     assert_eq!(
         md("abc <em><strong>line1<br />line2</strong> def</em>|"),
-        r#"abc _**line1\
-line2** def_"#,
+        r#"abc *__line1\
+line2__ def*"#,
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -83,6 +83,21 @@ line2__ def*"#,
     );
 }
 
+#[test]
+fn test_with_strikethrough() {
+    assert_eq!(md("<del>abc</del>|"), "~~abc~~");
+    assert_eq!(md("abc<del>def</del>ghi|"), "abc~~def~~ghi");
+    assert_eq!(md("abc <del>def</del> ghi|"), "abc ~~def~~ ghi");
+    assert_eq!(md("abc<del> def </del>ghi|"), "abc~~ def ~~ghi");
+    assert_eq!(
+        md("abc <del>line1<br />line2<br /><br />line3</del> def|"),
+        r#"abc ~~line1\
+line2\
+\
+line3~~ def"#,
+    );
+}
+
 fn md(html: &str) -> Utf16String {
     cm(html).state.dom.to_markdown().unwrap()
 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -19,6 +19,7 @@ use widestring::Utf16String;
 fn text() {
     assert_eq!(md("abc|"), "abc");
     assert_eq!(md("abc def|"), "abc def");
+    // Internal spaces are preserved.
     assert_eq!(md("abc   def|"), "abc   def");
 }
 
@@ -107,14 +108,22 @@ fn text_with_underline() {
 
 #[test]
 fn text_with_inline_code() {
-    assert_eq!(md("<code>abc</code>|"), "`abc`");
-    assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
-    assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
-    assert_eq!(md("abc<code> def </code>ghi|"), "abc` def `ghi");
+    assert_eq!(md("<code>abc</code>|"), "`` abc ``");
+    // Inline code with a backtick inside.
+    assert_eq!(md("<code>abc ` def</code>|"), "`` abc ` def ``");
+    // Inline code with a backtick at the start.
+    assert_eq!(md("<code>`abc</code>|"), "`` `abc ``");
+    assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
+    assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
+    assert_eq!(md("abc<code> def </code>ghi|"), "abc``  def  ``ghi");
     // It's impossible to get a line break inside a inline code with Markdown.
     assert_eq!(
         md("abc <code>line1<br />line2<br /><br />line3</code> def|"),
-        "abc `line1 line2  line3` def",
+        "abc `` line1 line2  line3 `` def",
+    );
+    assert_eq!(
+        md("abc <code>def <strong>ghi</strong> jkl</code> mno|"),
+        "abc `` def __ghi__ jkl `` mno",
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -12,22 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
+use crate::{tests::testutils_composer_model::cm, ToMarkdown};
+use widestring::Utf16String;
 
-pub mod test_characters;
-pub mod test_deleting;
-pub mod test_formatting;
-pub mod test_links;
-pub mod test_lists;
-pub mod test_menu_state;
-pub mod test_paragraphs;
-pub mod test_replace_all_html;
-pub mod test_selection;
-#[cfg(feature = "to-markdown")]
-pub mod test_to_markdown;
-pub mod test_to_raw_text;
-pub mod test_to_tree;
-pub mod test_undo_redo;
-pub mod testutils_composer_model;
-pub mod testutils_conversion;
-pub mod testutils_dom;
+#[test]
+fn text() {
+    assert_eq!(md("abc|"), "abc");
+}
+
+#[test]
+fn text_with_linebreaks() {
+    // One new line.
+    assert_eq!(
+        md("abc<br />def|"),
+        r#"abc\
+def"#
+    );
+
+    // Two new lines (isn't transformed into a new block).
+    assert_eq!(
+        md("abc<br /><br />def|"),
+        r#"abc\
+\
+def"#
+    );
+}
+
+fn md(html: &str) -> Utf16String {
+    cm(html).state.dom.to_markdown().unwrap()
+}

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -98,6 +98,11 @@ line3~~ def"#,
     );
 }
 
+#[test]
+fn test_with_underline() {
+    assert_eq!(md("<u>abc</u>|"), "abc");
+}
+
 fn md(html: &str) -> Utf16String {
     cm(html).state.dom.to_markdown().unwrap()
 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -18,24 +18,24 @@ use widestring::Utf16String;
 
 #[test]
 fn text() {
-    assert_eq!(md("abc|"), "abc");
-    assert_eq!(md("abc def|"), "abc def");
+    assert_to_md("abc", "abc");
+    assert_to_md("abc def", "abc def");
     // Internal spaces are preserved.
-    assert_eq!(md("abc   def|"), "abc   def");
+    assert_to_md("abc   def", "abc   def");
 }
 
 #[test]
 fn text_with_linebreaks() {
     // One new line.
-    assert_eq!(
-        md("abc<br />def|"),
+    assert_to_md(
+        "abc<br />def",
         r#"abc\
-def"#
+def"#,
     );
 
     // Two new lines (isn't transformed into a new block).
-    assert_eq!(
-        md("abc<br /><br />def|"),
+    assert_to_md(
+        "abc<br /><br />def",
         r#"abc\
 \
 def"#,
@@ -44,13 +44,13 @@ def"#,
 
 #[test]
 fn text_with_italic() {
-    assert_eq!(md("<em>abc</em>|"), "*abc*");
+    assert_to_md("<em>abc</em>", "*abc*");
     // Internal emphasis.
-    assert_eq!(md("abc<em>def</em>ghi|"), "abc*def*ghi");
-    assert_eq!(md("abc <em>def</em> ghi|"), "abc *def* ghi");
-    assert_eq!(md("abc<em> def </em>ghi|"), "abc* def *ghi");
-    assert_eq!(
-        md("abc <em>line1<br />line2<br /><br />line3</em> def|"),
+    assert_to_md("abc<em>def</em>ghi", "abc*def*ghi");
+    assert_to_md("abc <em>def</em> ghi", "abc *def* ghi");
+    assert_to_md_no_roundtrip("abc<em> def </em>ghi", "abc* def *ghi");
+    assert_to_md(
+        "abc <em>line1<br />line2<br /><br />line3</em> def",
         r#"abc *line1\
 line2\
 \
@@ -60,12 +60,15 @@ line3* def"#,
 
 #[test]
 fn text_with_bold() {
-    assert_eq!(md("<strong>abc</strong>|"), "__abc__");
-    assert_eq!(md("abc<strong>def</strong>ghi|"), "abc__def__ghi");
-    assert_eq!(md("abc <strong>def</strong> ghi|"), "abc __def__ ghi");
-    assert_eq!(md("abc<strong> def </strong>ghi|"), "abc__ def __ghi");
-    assert_eq!(
-        md("abc <strong>line1<br />line2<br /><br />line3</strong> def|"),
+    assert_to_md("<strong>abc</strong>", "__abc__");
+    assert_to_md_no_roundtrip("abc<strong>def</strong>ghi", "abc__def__ghi");
+    assert_to_md("abc <strong>def</strong> ghi", "abc __def__ ghi");
+    assert_to_md_no_roundtrip(
+        "abc<strong> def </strong>ghi",
+        "abc__ def __ghi",
+    );
+    assert_to_md(
+        "abc <strong>line1<br />line2<br /><br />line3</strong> def",
         r#"abc __line1\
 line2\
 \
@@ -75,13 +78,10 @@ line3__ def"#,
 
 #[test]
 fn text_with_italic_and_bold() {
-    assert_eq!(md("<em><strong>abc</strong></em>|"), "*__abc__*");
-    assert_eq!(
-        md("<em>abc <strong>def</strong></em> ghi|"),
-        "*abc __def__* ghi"
-    );
-    assert_eq!(
-        md("abc <em><strong>line1<br />line2</strong> def</em>|"),
+    assert_to_md("<em><strong>abc</strong></em>", "*__abc__*");
+    assert_to_md("<em>abc <strong>def</strong></em> ghi", "*abc __def__* ghi");
+    assert_to_md(
+        "abc <em><strong>line1<br />line2</strong> def</em>",
         r#"abc *__line1\
 line2__ def*"#,
     );
@@ -89,12 +89,12 @@ line2__ def*"#,
 
 #[test]
 fn text_with_strikethrough() {
-    assert_eq!(md("<del>abc</del>|"), "~~abc~~");
-    assert_eq!(md("abc<del>def</del>ghi|"), "abc~~def~~ghi");
-    assert_eq!(md("abc <del>def</del> ghi|"), "abc ~~def~~ ghi");
-    assert_eq!(md("abc<del> def </del>ghi|"), "abc~~ def ~~ghi");
-    assert_eq!(
-        md("abc <del>line1<br />line2<br /><br />line3</del> def|"),
+    assert_to_md("<del>abc</del>", "~~abc~~");
+    assert_to_md_no_roundtrip("abc<del>def</del>ghi", "abc~~def~~ghi");
+    assert_to_md("abc <del>def</del> ghi", "abc ~~def~~ ghi");
+    assert_to_md_no_roundtrip("abc<del> def </del>ghi", "abc~~ def ~~ghi");
+    assert_to_md(
+        "abc <del>line1<br />line2<br /><br />line3</del> def",
         r#"abc ~~line1\
 line2\
 \
@@ -104,56 +104,53 @@ line3~~ def"#,
 
 #[test]
 fn text_with_underline() {
-    assert_eq!(md("<u>abc</u>|"), "abc");
+    assert_to_md_no_roundtrip("<u>abc</u>", "abc");
 }
 
 #[test]
 fn text_with_inline_code() {
-    assert_eq!(md("<code>abc</code>|"), "`` abc ``");
+    assert_to_md("<code>abc</code>", "`` abc ``");
     // Inline code with a backtick inside.
-    assert_eq!(md("<code>abc ` def</code>|"), "`` abc ` def ``");
+    assert_to_md("<code>abc ` def</code>", "`` abc ` def ``");
     // Inline code with a backtick at the start.
-    assert_eq!(md("<code>`abc</code>|"), "`` `abc ``");
-    assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
-    assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
-    assert_eq!(md("abc<code> def </code>ghi|"), "abc``  def  ``ghi");
+    assert_to_md("<code>`abc</code>", "`` `abc ``");
+    assert_to_md("abc <code>def</code> ghi", "abc `` def `` ghi");
+    assert_to_md("abc<code> def </code>ghi", "abc``  def  ``ghi");
     // It's impossible to get a line break inside an inline code with Markdown.
-    assert_eq!(
-        md("abc <code>line1<br />line2<br /><br />line3</code> def|"),
+    assert_to_md_no_roundtrip(
+        "abc <code>line1<br />line2<br /><br />line3</code> def",
         "abc `` line1 line2  line3 `` def",
     );
-    assert_eq!(
-        md("abc <code>def <strong>ghi</strong> jkl</code> mno|"),
+    assert_to_md_no_roundtrip(
+        "abc <code>def <strong>ghi</strong> jkl</code> mno",
         "abc `` def __ghi__ jkl `` mno",
     );
 }
 
 #[test]
 fn link() {
-    assert_eq!(md(r#"<a href="url">abc</a>|"#), "[abc](<url>)");
-    assert_eq!(md(r#"<a href="u<rl">abc</a>|"#), r#"[abc](<u\<rl>)"#);
+    assert_to_md(r#"<a href="url">abc</a>"#, "[abc](<url>)");
+    assert_to_md_no_roundtrip(r#"<a href="u<rl">abc</a>"#, r#"[abc](<u\<rl>)"#);
     // Empty link.
-    assert_eq!(md(r#"<a href="">abc</a>|"#), r#"[abc](<>)"#);
+    assert_to_md(r#"<a href="">abc</a>"#, r#"[abc](<>)"#);
     // Formatting inside link.
-    assert_eq!(
-        md(r#"<a href="url">abc <strong>def</strong> ghi</a>|"#),
-        r#"[abc __def__ ghi](<url>)"#
+    assert_to_md(
+        r#"<a href="url">abc <strong>def</strong> ghi</a>"#,
+        r#"[abc __def__ ghi](<url>)"#,
     );
-    assert_eq!(md(r#"<a href="(url)">abc</a>|"#), r#"[abc](<\(url\)>)"#);
+    assert_to_md(r#"<a href="(url)">abc</a>"#, r#"[abc](<\(url\)>)"#);
 }
 
 #[test]
 fn list_unordered() {
-    assert_eq!(
-        md(r#"<ul><li>item1</li><li>item2</li></ul>|"#),
+    assert_to_md(
+        r#"<ul><li>item1</li><li>item2</li></ul>"#,
         r#"* item1
-* item2"#
+* item2"#,
     );
 
-    assert_eq!(
-        md(
-            r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>|"#,
-        ),
+    assert_to_md_no_roundtrip(
+        r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>"#,
         r#"* item1
   * subitem1
   * subitem2
@@ -163,46 +160,75 @@ fn list_unordered() {
 
 #[test]
 fn list_ordered() {
-    assert_eq!(
-        md(r#"<ol><li>item1</li><li>item2</li></ol>|"#),
+    assert_to_md(
+        r#"<ol><li>item1</li><li>item2</li></ol>"#,
         r#"1. item1
-2. item2"#
+2. item2"#,
     );
 }
 
 #[test]
 fn round_trip() {
-    assert_roundtrip(r#"hello <strong>world</strong>!"#, "hello __world__!");
+    assert_to_md(r#"hello <strong>world</strong>!"#, "hello __world__!");
 }
 
-fn md(html: &str) -> Utf16String {
-    cm(html).state.dom.to_markdown().unwrap()
-}
-
-fn assert_roundtrip(html: &str, expected_markdown: &str) {
+fn to_markdown(html: &str) -> Utf16String {
     let markdown = cm(&format!("{html}|")).state.dom.to_markdown();
     assert!(markdown.is_ok());
-    let markdown = markdown.unwrap();
 
+    markdown.unwrap()
+}
+
+fn to_html(markdown: &Utf16String) -> String {
+    use md_parser::{html, Options, Parser};
+
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+
+    let markdown = markdown.as_ustr().to_string_lossy();
+
+    let parser = Parser::new_ext(&markdown, options);
+
+    let mut html = String::new();
+    html::push_html(&mut html, parser);
+
+    // By default, there is a `<p>…</p>\n` around the HTML content. That's the
+    // correct way to handle a text block in Markdown. But it breaks our
+    // assumption regarding the HTML markup. So let's remove it.
+    let html = {
+        if !html.starts_with("<p>") {
+            &html[..]
+        } else {
+            let p = "<p>".len();
+            let ppnl = "</p>\n".len();
+
+            &html[p..html.len() - ppnl]
+        }
+    };
+
+    // Format new lines.
+    let html = html
+        .replace("<ul>\n", "<ul>")
+        .replace("</ul>\n", "</ul>")
+        .replace("<ol>\n", "<ol>")
+        .replace("</ol>\n", "</ol>")
+        .replace("</li>\n", "</li>")
+        .replace("<br />\n", "<br />");
+
+    html
+}
+
+fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {
+    let markdown = to_markdown(html);
+    assert_eq!(markdown, expected_markdown);
+}
+
+fn assert_to_md(html: &str, expected_markdown: &str) {
+    let markdown = to_markdown(html);
     assert_eq!(markdown, expected_markdown);
 
     let expected_html = html;
-    let html = {
-        let mut options = md_parser::Options::empty();
-        options.insert(md_parser::Options::ENABLE_STRIKETHROUGH);
+    let html = to_html(&markdown);
 
-        let markdown = markdown.as_ustr().to_string_lossy();
-
-        let parser = md_parser::Parser::new_ext(&markdown, options);
-
-        let mut html = String::new();
-        md_parser::html::push_html(&mut html, parser);
-
-        html
-    };
-
-    let p = "<p>".len();
-    let ppnl = "</p>\n".len();
-
-    assert_eq!(&html[p..html.len() - ppnl], expected_html);
+    assert_eq!(html, expected_html);
 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -167,11 +167,20 @@ fn list_ordered() {
     );
 }
 
-#[test]
-fn round_trip() {
-    assert_to_md(r#"hello <strong>world</strong>!"#, "hello __world__!");
+fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {
+    let markdown = to_markdown(html);
+    assert_eq!(markdown, expected_markdown);
 }
 
+fn assert_to_md(html: &str, expected_markdown: &str) {
+    let markdown = to_markdown(html);
+    assert_eq!(markdown, expected_markdown);
+
+    let expected_html = html;
+    let html = to_html(&markdown);
+
+    assert_eq!(html, expected_html);
+}
 fn to_markdown(html: &str) -> Utf16String {
     let markdown = cm(&format!("{html}|")).state.dom.to_markdown();
     assert!(markdown.is_ok());
@@ -216,19 +225,4 @@ fn to_html(markdown: &Utf16String) -> String {
         .replace("<br />\n", "<br />");
 
     html
-}
-
-fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {
-    let markdown = to_markdown(html);
-    assert_eq!(markdown, expected_markdown);
-}
-
-fn assert_to_md(html: &str, expected_markdown: &str) {
-    let markdown = to_markdown(html);
-    assert_eq!(markdown, expected_markdown);
-
-    let expected_html = html;
-    let html = to_html(&markdown);
-
-    assert_eq!(html, expected_html);
 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -34,7 +34,21 @@ def"#
         md("abc<br /><br />def|"),
         r#"abc\
 \
-def"#
+def"#,
+    );
+}
+
+#[test]
+fn test_with_bold() {
+    assert_eq!(md("<strong>abc</strong>|"), "**abc**");
+    assert_eq!(md("abc <strong>def</strong> ghi|"), "abc **def** ghi");
+    assert_eq!(md("abc<strong> def </strong>ghi|"), "abc** def **ghi");
+    assert_eq!(
+        md("abc <strong>line1<br />line2<br /><br />line3</strong> def|"),
+        r#"abc **line1\
+line2\
+\
+line3** def"#,
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -127,6 +127,11 @@ fn text_with_inline_code() {
     );
 }
 
+#[test]
+fn link() {
+    assert_eq!(md(r#"<a href="url">abc</a>|"#), "[abc](url)");
+}
+
 fn md(html: &str) -> Utf16String {
     cm(html).state.dom.to_markdown().unwrap()
 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -39,7 +39,7 @@ def"#,
 }
 
 #[test]
-fn test_with_italic() {
+fn text_with_italic() {
     assert_eq!(md("<em>abc</em>|"), "*abc*");
     // Internal emphasis.
     assert_eq!(md("abc<em>def</em>ghi|"), "abc*def*ghi");
@@ -55,7 +55,7 @@ line3* def"#,
 }
 
 #[test]
-fn test_with_bold() {
+fn text_with_bold() {
     assert_eq!(md("<strong>abc</strong>|"), "__abc__");
     assert_eq!(md("abc<strong>def</strong>ghi|"), "abc__def__ghi");
     assert_eq!(md("abc <strong>def</strong> ghi|"), "abc __def__ ghi");
@@ -70,7 +70,7 @@ line3__ def"#,
 }
 
 #[test]
-fn test_with_italic_and_bold() {
+fn text_with_italic_and_bold() {
     assert_eq!(md("<em><strong>abc</strong></em>|"), "*__abc__*");
     assert_eq!(
         md("<em>abc <strong>def</strong></em> ghi|"),
@@ -84,7 +84,7 @@ line2__ def*"#,
 }
 
 #[test]
-fn test_with_strikethrough() {
+fn text_with_strikethrough() {
     assert_eq!(md("<del>abc</del>|"), "~~abc~~");
     assert_eq!(md("abc<del>def</del>ghi|"), "abc~~def~~ghi");
     assert_eq!(md("abc <del>def</del> ghi|"), "abc ~~def~~ ghi");
@@ -99,8 +99,21 @@ line3~~ def"#,
 }
 
 #[test]
-fn test_with_underline() {
+fn text_with_underline() {
     assert_eq!(md("<u>abc</u>|"), "abc");
+}
+
+#[test]
+fn text_with_inline_code() {
+    assert_eq!(md("<code>abc</code>|"), "`abc`");
+    assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
+    assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
+    assert_eq!(md("abc<code> def </code>ghi|"), "abc` def `ghi");
+    // It's impossible to get line break in inline code with Markdown.
+    assert_eq!(
+        md("abc <code>line1<br />line2<br /><br />line3</code> def|"),
+        "abc `line1 line2  line3` def",
+    );
 }
 
 fn md(html: &str) -> Utf16String {

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -165,6 +165,25 @@ fn list_ordered() {
         r#"1. item1
 2. item2"#,
     );
+
+    assert_to_md_no_roundtrip(
+        r#"<ol><li>item1<ol><li>subitem1</li><li>subitem2</li></ol></li><li>item2</li></ol>"#,
+        r#"1. item1
+  1. subitem1
+  2. subitem2
+2. item2"#,
+    );
+}
+
+#[test]
+fn list_ordered_and_unordered() {
+    assert_to_md_no_roundtrip(
+        r#"<ol><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ol>"#,
+        r#"1. item1
+  * subitem1
+  * subitem2
+2. item2"#,
+    );
 }
 
 fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -208,7 +208,7 @@ fn to_markdown(html: &str) -> Utf16String {
 }
 
 fn to_html(markdown: &Utf16String) -> String {
-    use md_parser::{html, Options, Parser};
+    use md_parser::{html::push_html as compile_to_html, Options, Parser};
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -218,7 +218,7 @@ fn to_html(markdown: &Utf16String) -> String {
     let parser = Parser::new_ext(&markdown, options);
 
     let mut html = String::new();
-    html::push_html(&mut html, parser);
+    compile_to_html(&mut html, parser);
 
     // By default, there is a `<p>…</p>\n` around the HTML content. That's the
     // correct way to handle a text block in Markdown. But it breaks our

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -116,7 +116,7 @@ fn text_with_inline_code() {
     assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
     assert_eq!(md("abc <code>def</code> ghi|"), "abc `` def `` ghi");
     assert_eq!(md("abc<code> def </code>ghi|"), "abc``  def  ``ghi");
-    // It's impossible to get a line break inside a inline code with Markdown.
+    // It's impossible to get a line break inside an inline code with Markdown.
     assert_eq!(
         md("abc <code>line1<br />line2<br /><br />line3</code> def|"),
         "abc `` line1 line2  line3 `` def",
@@ -139,6 +139,34 @@ fn link() {
         r#"[abc __def__ ghi](<url>)"#
     );
     assert_eq!(md(r#"<a href="(url)">abc</a>|"#), r#"[abc](<\(url\)>)"#);
+}
+
+#[test]
+fn list_unordered() {
+    assert_eq!(
+        md(r#"<ul><li>item1</li><li>item2</li></ul>|"#),
+        r#"* item1
+* item2"#
+    );
+
+    assert_eq!(
+        md(
+            r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>|"#,
+        ),
+        r#"* item1
+  * subitem1
+  * subitem2
+* item2"#,
+    );
+}
+
+#[test]
+fn list_ordered() {
+    assert_eq!(
+        md(r#"<ol><li>item1</li><li>item2</li></ol>|"#),
+        r#"1. item1
+2. item2"#
+    );
 }
 
 fn md(html: &str) -> Utf16String {

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -129,7 +129,16 @@ fn text_with_inline_code() {
 
 #[test]
 fn link() {
-    assert_eq!(md(r#"<a href="url">abc</a>|"#), "[abc](url)");
+    assert_eq!(md(r#"<a href="url">abc</a>|"#), "[abc](<url>)");
+    assert_eq!(md(r#"<a href="u<rl">abc</a>|"#), r#"[abc](<u\<rl>)"#);
+    // Empty link.
+    assert_eq!(md(r#"<a href="">abc</a>|"#), r#"[abc](<>)"#);
+    // Formatting inside link.
+    assert_eq!(
+        md(r#"<a href="url">abc <strong>def</strong> ghi</a>|"#),
+        r#"[abc __def__ ghi](<url>)"#
+    );
+    assert_eq!(md(r#"<a href="(url)">abc</a>|"#), r#"[abc](<\(url\)>)"#);
 }
 
 fn md(html: &str) -> Utf16String {

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -18,6 +18,8 @@ use widestring::Utf16String;
 #[test]
 fn text() {
     assert_eq!(md("abc|"), "abc");
+    assert_eq!(md("abc def|"), "abc def");
+    assert_eq!(md("abc   def|"), "abc   def");
 }
 
 #[test]
@@ -109,7 +111,7 @@ fn text_with_inline_code() {
     assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
     assert_eq!(md("abc <code>def</code> ghi|"), "abc `def` ghi");
     assert_eq!(md("abc<code> def </code>ghi|"), "abc` def `ghi");
-    // It's impossible to get line break in inline code with Markdown.
+    // It's impossible to get a line break inside a inline code with Markdown.
     assert_eq!(
         md("abc <code>line1<br />line2<br /><br />line3</code> def|"),
         "abc `line1 line2  line3` def",

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -39,6 +39,20 @@ def"#,
 }
 
 #[test]
+fn test_with_italic() {
+    assert_eq!(md("<em>abc</em>|"), "_abc_");
+    assert_eq!(md("abc <em>def</em> ghi|"), "abc _def_ ghi");
+    assert_eq!(md("abc<em> def </em>ghi|"), "abc_ def _ghi");
+    assert_eq!(
+        md("abc <em>line1<br />line2<br /><br />line3</em> def|"),
+        r#"abc _line1\
+line2\
+\
+line3_ def"#,
+    );
+}
+
+#[test]
 fn test_with_bold() {
     assert_eq!(md("<strong>abc</strong>|"), "**abc**");
     assert_eq!(md("abc <strong>def</strong> ghi|"), "abc **def** ghi");
@@ -49,6 +63,20 @@ fn test_with_bold() {
 line2\
 \
 line3** def"#,
+    );
+}
+
+#[test]
+fn test_with_italic_and_bold() {
+    assert_eq!(md("<em><strong>abc</strong></em>|"), "_**abc**_");
+    assert_eq!(
+        md("<em>abc <strong>def</strong></em> ghi|"),
+        "_abc **def**_ ghi"
+    );
+    assert_eq!(
+        md("abc <em><strong>line1<br />line2</strong> def</em>|"),
+        r#"abc _**line1\
+line2** def_"#,
     );
 }
 


### PR DESCRIPTION
This PR adds a new trait: `ToMardown` behind a new `to-markdown` Cargo feature. It allows to transform a DOM tree into Markdown.

In the test suite, by default, `assert_to_md` will roundtrip from HTML to Markdown, to HTML again. Otherwise, I've used `assert_to_md_no_roundtrip`. It happens when the Markdown to HTML compiler isn't able to parse our generated Markdown (it seems to be a bug, because it works with other parsers…) or because there is some formatting added (like newlines). This “roundtrip guarantee” isn't necessary for now. I was anticipating a next feature :-).

## Progress

- [x] line break node
- [x] text node
- [x] container node
  - [x] generic node
  - [x] formatting node
    - [x] bold
    - [x] italic
    - [x] strike through
    - [x] underline
    - [x] inline code 
  - [x] link node
  - [x] list node
  - [x] list item node