### PR TITLE
Toggle format with no selection

### DIFF
--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -15,7 +15,9 @@
 use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
 use crate::dom::{DomHandle, UnicodeString};
-use crate::{ComposerAction, ComposerUpdate, Location, ToHtml, ToTree};
+use crate::{
+    ComposerAction, ComposerUpdate, InlineFormatType, Location, ToHtml, ToTree,
+};
 use std::collections::HashSet;
 
 #[derive(Clone)]
@@ -28,6 +30,7 @@ where
     pub next_states: Vec<ComposerState<S>>,
     pub reversed_actions: HashSet<ComposerAction>,
     pub disabled_actions: HashSet<ComposerAction>,
+    pub toggled_format_types: Vec<InlineFormatType>,
 }
 
 impl<S> ComposerModel<S>
@@ -41,6 +44,18 @@ where
             next_states: Vec::new(),
             reversed_actions: HashSet::new(),
             disabled_actions: HashSet::new(),
+            toggled_format_types: Vec::new(),
+        }
+    }
+
+    pub fn from_state(state: ComposerState<S>) -> Self {
+        Self {
+            state: state,
+            previous_states: Vec::new(),
+            next_states: Vec::new(),
+            reversed_actions: HashSet::new(),
+            disabled_actions: HashSet::new(),
+            toggled_format_types: Vec::new(),
         }
     }
 
@@ -61,6 +76,7 @@ where
             next_states: Vec::new(),
             reversed_actions: HashSet::new(),
             disabled_actions: HashSet::new(),
+            toggled_format_types: Vec::new(),
         };
         model.compute_menu_state();
         model

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -16,7 +16,7 @@ use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
 use crate::dom::{DomHandle, UnicodeString};
 use crate::{
-    ComposerAction, ComposerUpdate, InlineFormatType, Location, ToHtml, ToTree,
+    ComposerAction, ComposerUpdate, Location, ToHtml, ToTree,
 };
 use std::collections::HashSet;
 
@@ -30,7 +30,6 @@ where
     pub next_states: Vec<ComposerState<S>>,
     pub reversed_actions: HashSet<ComposerAction>,
     pub disabled_actions: HashSet<ComposerAction>,
-    pub toggled_format_types: Vec<InlineFormatType>,
 }
 
 impl<S> ComposerModel<S>
@@ -44,7 +43,6 @@ where
             next_states: Vec::new(),
             reversed_actions: HashSet::new(),
             disabled_actions: HashSet::new(),
-            toggled_format_types: Vec::new(),
         }
     }
 
@@ -55,7 +53,6 @@ where
             next_states: Vec::new(),
             reversed_actions: HashSet::new(),
             disabled_actions: HashSet::new(),
-            toggled_format_types: Vec::new(),
         }
     }
 
@@ -71,12 +68,12 @@ where
                 dom: parse(html).expect("HTML parsing failed"),
                 start: Location::from(start_codeunit),
                 end: Location::from(end_codeunit),
+                toggled_format_types: Vec::new(),
             },
             previous_states: Vec::new(),
             next_states: Vec::new(),
             reversed_actions: HashSet::new(),
             disabled_actions: HashSet::new(),
-            toggled_format_types: Vec::new(),
         };
         model.compute_menu_state();
         model

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -15,9 +15,7 @@
 use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
 use crate::dom::{DomHandle, UnicodeString};
-use crate::{
-    ComposerAction, ComposerUpdate, Location, ToHtml, ToTree,
-};
+use crate::{ComposerAction, ComposerUpdate, Location, ToHtml, ToTree};
 use std::collections::HashSet;
 
 #[derive(Clone)]

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Not;
 
 use widestring::Utf16String;
@@ -21,9 +21,7 @@ use crate::dom::nodes::{LineBreakNode, TextNode};
 use crate::dom::parser::parse;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::DomLocation;
-use crate::{
-    ComposerModel, ComposerState, DomHandle, Location, ToHtml, UnicodeString,
-};
+use crate::{ComposerModel, DomHandle, Location, ToHtml, UnicodeString};
 
 impl ComposerModel<Utf16String> {
     /// Convenience function to allow working with ComposerModel instances
@@ -94,13 +92,7 @@ impl ComposerModel<Utf16String> {
         let s = find_char(&text_u16, "{");
         let e = find_char(&text_u16, "}");
 
-        let mut model = ComposerModel {
-            state: ComposerState::new(),
-            previous_states: Vec::new(),
-            next_states: Vec::new(),
-            reversed_actions: HashSet::new(),
-            disabled_actions: HashSet::new(),
-        };
+        let mut model = ComposerModel::new();
         model.state.dom = parse(&text).unwrap();
 
         fn delete_range(
@@ -417,8 +409,6 @@ impl SelectionWritingState {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
-
     use speculoos::{prelude::*, AssertionFailure, Spec};
     use widestring::Utf16String;
 
@@ -598,49 +588,34 @@ mod test {
 
     #[test]
     fn tx_formats_selection_spanning_outwards_from_tag_forwards() {
-        let model: ComposerModel<Utf16String> = ComposerModel {
-            state: ComposerState {
+        let model: ComposerModel<Utf16String> =
+            ComposerModel::from_state(ComposerState {
                 dom: parser::parse("AAA<b>BBB</b>CCC").unwrap(),
                 start: Location::from(4),
                 end: Location::from(7),
-            },
-            previous_states: Vec::new(),
-            next_states: Vec::new(),
-            reversed_actions: HashSet::new(),
-            disabled_actions: HashSet::new(),
-        };
+            });
         assert_eq!(tx(&model), "AAA<b>B{BB</b>C}|CC");
     }
 
     #[test]
     fn tx_formats_selection_spanning_outwards_from_tag_backwards() {
-        let model: ComposerModel<Utf16String> = ComposerModel {
-            state: ComposerState {
+        let model: ComposerModel<Utf16String> =
+            ComposerModel::from_state(ComposerState {
                 dom: parser::parse("AAA<b>BBB</b>CCC").unwrap(),
                 start: Location::from(7),
                 end: Location::from(4),
-            },
-            previous_states: Vec::new(),
-            next_states: Vec::new(),
-            reversed_actions: HashSet::new(),
-            disabled_actions: HashSet::new(),
-        };
+            });
         assert_eq!(tx(&model), "AAA<b>B|{BB</b>C}CC");
     }
 
     #[test]
     fn tx_formats_empty_model() {
-        let model: ComposerModel<Utf16String> = ComposerModel {
-            state: ComposerState {
+        let model: ComposerModel<Utf16String> =
+            ComposerModel::from_state(ComposerState {
                 dom: Dom::new(Vec::new()),
                 start: Location::from(1),
                 end: Location::from(1),
-            },
-            previous_states: Vec::new(),
-            next_states: Vec::new(),
-            reversed_actions: HashSet::new(),
-            disabled_actions: HashSet::new(),
-        };
+            });
         assert_eq!(tx(&model), "");
     }
 

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -593,6 +593,7 @@ mod test {
                 dom: parser::parse("AAA<b>BBB</b>CCC").unwrap(),
                 start: Location::from(4),
                 end: Location::from(7),
+                toggled_format_types: Vec::new(),
             });
         assert_eq!(tx(&model), "AAA<b>B{BB</b>C}|CC");
     }
@@ -604,6 +605,7 @@ mod test {
                 dom: parser::parse("AAA<b>BBB</b>CCC").unwrap(),
                 start: Location::from(7),
                 end: Location::from(4),
+                toggled_format_types: Vec::new(),
             });
         assert_eq!(tx(&model), "AAA<b>B|{BB</b>C}CC");
     }
@@ -615,6 +617,7 @@ mod test {
                 dom: Dom::new(Vec::new()),
                 start: Location::from(1),
                 end: Location::from(1),
+                toggled_format_types: Vec::new(),
             });
         assert_eq!(tx(&model), "");
     }

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -74,14 +74,14 @@ where
     }
 
     pub(crate) fn apply_pending_formats(&mut self, start: usize, end: usize) {
-        self.toggled_format_types.clone().iter().for_each(|format| {
+        self.state.toggled_format_types.clone().iter().for_each(|format| {
             if self.reversed_actions.contains(&format.action()) {
                 self.format_range(start, end, format.clone());
             } else {
                 self.unformat_range(start, end, format.clone());
             }
         });
-        self.toggled_format_types.clear();
+        self.state.toggled_format_types.clear();
     }
 
     fn format(&mut self, format: InlineFormatType) -> ComposerUpdate<S> {
@@ -132,12 +132,12 @@ where
     }
 
     fn toggle_zero_length_format(&mut self, format: InlineFormatType) {
-        if self.toggled_format_types.contains(&format) {
-            self.toggled_format_types
+        if self.state.toggled_format_types.contains(&format) {
+            self.state.toggled_format_types
                 .iter()
                 .position(|f| f.clone() == format);
         } else {
-            self.toggled_format_types.push(format);
+            self.state.toggled_format_types.push(format);
         }
     }
 

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -75,6 +75,19 @@ where
                     .collect();
                 reversed_actions = intersection;
             }
+
+            let toggled_format_actions = self
+                .toggled_format_types
+                .iter()
+                .map(|format| format.action())
+                .collect();
+
+            reversed_actions = reversed_actions
+                .symmetric_difference(&toggled_format_actions)
+                .into_iter()
+                .cloned()
+                .collect();
+
             reversed_actions
         }
     }

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -77,6 +77,7 @@ where
             }
 
             let toggled_format_actions = self
+                .state
                 .toggled_format_types
                 .iter()
                 .map(|format| format.action())

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -109,6 +109,8 @@ where
             self.replace_multiple_nodes(range, new_text)
         }
 
+        self.apply_pending_formats(start, start + len);
+
         self.state.start = Location::from(start + len);
         self.state.end = self.state.start;
 

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -25,7 +25,7 @@ where
         start: Location,
         end: Location,
     ) -> ComposerUpdate<S> {
-        self.toggled_format_types.clear();
+        self.state.toggled_format_types.clear();
         self.state.start = start;
         self.state.end = end;
 

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -25,6 +25,7 @@ where
         start: Location,
         end: Location,
     ) -> ComposerUpdate<S> {
+        self.toggled_format_types.clear();
         self.state.start = start;
         self.state.end = end;
 

--- a/crates/wysiwyg/src/composer_state.rs
+++ b/crates/wysiwyg/src/composer_state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::dom::{Dom, UnicodeString};
-use crate::Location;
+use crate::{ InlineFormatType, Location };
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ComposerState<S>
@@ -23,6 +23,7 @@ where
     pub dom: Dom<S>,
     pub start: Location,
     pub end: Location,
+    pub toggled_format_types: Vec<InlineFormatType>,
 }
 
 impl<S> ComposerState<S>
@@ -34,6 +35,7 @@ where
             dom: Dom::new(Vec::new()),
             start: Location::from(0),
             end: Location::from(0),
+            toggled_format_types: Vec::new(),
         }
     }
 }

--- a/crates/wysiwyg/src/composer_state.rs
+++ b/crates/wysiwyg/src/composer_state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::dom::{Dom, UnicodeString};
-use crate::{ InlineFormatType, Location };
+use crate::{InlineFormatType, Location};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ComposerState<S>

--- a/crates/wysiwyg/src/composer_update.rs
+++ b/crates/wysiwyg/src/composer_update.rs
@@ -35,6 +35,13 @@ where
         }
     }
 
+    pub fn update_menu_state(menu_state: MenuState) -> Self {
+        Self {
+            text_update: TextUpdate::<S>::Keep,
+            menu_state: menu_state,
+        }
+    }
+
     pub fn update_selection(
         start: Location,
         end: Location,

--- a/crates/wysiwyg/src/format_type.rs
+++ b/crates/wysiwyg/src/format_type.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::UnicodeString;
+use crate::{ComposerAction, UnicodeString};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum InlineFormatType {
@@ -31,6 +31,16 @@ impl InlineFormatType {
             InlineFormatType::StrikeThrough => "del",
             InlineFormatType::Underline => "u",
             InlineFormatType::InlineCode => "code",
+        }
+    }
+
+    pub fn action(&self) -> ComposerAction {
+        match self {
+            InlineFormatType::Bold => ComposerAction::Bold,
+            InlineFormatType::Italic => ComposerAction::Italic,
+            InlineFormatType::StrikeThrough => ComposerAction::StrikeThrough,
+            InlineFormatType::Underline => ComposerAction::Underline,
+            InlineFormatType::InlineCode => ComposerAction::InlineCode,
         }
     }
 }

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -126,7 +126,7 @@ fn formatting_with_zero_length_selection_apply_on_replace_text() {
     model.underline();
     assert_eq!(tx(&model), "aaa|bbb");
     assert_eq!(
-        model.toggled_format_types,
+        model.state.toggled_format_types,
         Vec::from([
             InlineFormatType::Bold,
             InlineFormatType::Italic,
@@ -142,7 +142,7 @@ fn unformatting_with_zero_length_selection_removes_on_replace_text() {
     let mut model = cm("<strong>aaa|bbb</strong>");
     model.bold();
     assert_eq!(
-        model.toggled_format_types,
+        model.state.toggled_format_types,
         Vec::from([InlineFormatType::Bold]),
     );
     model.replace_text(utf16("ccc"));
@@ -163,9 +163,9 @@ fn selecting_removes_toggled_format_types() {
     let mut model = cm("aaa|");
     model.bold();
     assert_eq!(
-        model.toggled_format_types,
+        model.state.toggled_format_types,
         Vec::from([InlineFormatType::Bold]),
     );
     model.select(Location::from(2), Location::from(2));
-    assert_eq!(model.toggled_format_types, Vec::new(),);
+    assert_eq!(model.state.toggled_format_types, Vec::new(),);
 }

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -21,7 +21,7 @@ use widestring::Utf16String;
 use crate::tests::testutils_composer_model::cm;
 use crate::tests::testutils_conversion::utf16;
 
-use crate::{ComposerAction, ComposerModel, InlineFormatType, Location};
+use crate::{ComposerAction, ComposerModel, Location};
 
 #[test]
 fn creating_and_deleting_lists_updates_reversed_actions() {
@@ -86,9 +86,9 @@ fn selecting_multiple_nodes_updates_reversed_actions() {
 #[test]
 fn formatting_updates_reversed_actions() {
     let mut model = cm("a{bc}|d");
-    model.format(InlineFormatType::Bold);
-    model.format(InlineFormatType::Italic);
-    model.format(InlineFormatType::Underline);
+    model.bold();
+    model.italic();
+    model.underline();
     assert_eq!(
         model.reversed_actions,
         HashSet::from([
@@ -113,7 +113,7 @@ fn updating_model_updates_disabled_actions() {
     );
     replace_text(&mut model, "a");
     model.select(Location::from(0), Location::from(1));
-    model.format(InlineFormatType::Bold);
+    model.bold();
     assert_eq!(
         model.disabled_actions,
         HashSet::from([
@@ -145,6 +145,29 @@ fn updating_model_updates_disabled_actions() {
             ComposerAction::Indent,
             ComposerAction::UnIndent
         ])
+    );
+}
+
+#[test]
+fn formatting_zero_length_selection_updates_reversed_actions() {
+    let mut model = cm("<strong><em>aaa|bbb</em></strong>");
+    model.bold();
+    model.underline();
+    assert_eq!(
+        model.reversed_actions,
+        HashSet::from([ComposerAction::Italic, ComposerAction::Underline,]),
+    );
+}
+
+#[test]
+fn selecting_restores_reversed_actions() {
+    let mut model = cm("<strong><em>aaa|bbb</em></strong>");
+    model.bold();
+    model.underline();
+    model.select(Location::from(2), Location::from(2));
+    assert_eq!(
+        model.reversed_actions,
+        HashSet::from([ComposerAction::Bold, ComposerAction::Italic,]),
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_selection.rs
+++ b/crates/wysiwyg/src/tests/test_selection.rs
@@ -16,7 +16,7 @@
 
 use crate::tests::testutils_composer_model::{cm, tx};
 
-use crate::{InlineFormatType, Location, TextUpdate};
+use crate::{Location, TextUpdate};
 
 #[test]
 fn selecting_ascii_characters() {
@@ -97,7 +97,7 @@ fn selecting_complex_characters() {
 #[test]
 fn selecting_within_a_tag() {
     let mut model = cm("ad|{asda}sf");
-    model.format(InlineFormatType::Bold);
+    model.bold();
     model.select(Location::from(3), Location::from(7));
     assert_eq!(tx(&model), "ad<strong>a{sda</strong>s}|f");
 }

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -17,6 +17,7 @@
 use crate::tests::testutils_composer_model::cm;
 
 use crate::dom::nodes::{DomNode, TextNode};
+use crate::InlineFormatType;
 
 use crate::tests::testutils_conversion::utf16;
 
@@ -107,4 +108,31 @@ fn redoing_action_adds_popped_state_to_previous_states() {
     model.redo();
 
     assert_eq!(model.previous_states[0], model.state);
+}
+
+#[test]
+fn undoing_restores_toggled_format_types() {
+    let mut model = cm("|");
+    model.bold();
+    model.italic();
+    assert_eq!(
+        model.state.toggled_format_types,
+        Vec::from([
+            InlineFormatType::Bold,
+            InlineFormatType::Italic,
+        ])
+    );
+    model.replace_text(utf16("a"));
+    assert_eq!(
+        model.state.toggled_format_types,
+        Vec::new()
+    );
+    model.undo();
+    assert_eq!(
+        model.state.toggled_format_types,
+        Vec::from([
+            InlineFormatType::Bold,
+            InlineFormatType::Italic,
+        ])
+    );
 }

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -117,22 +117,13 @@ fn undoing_restores_toggled_format_types() {
     model.italic();
     assert_eq!(
         model.state.toggled_format_types,
-        Vec::from([
-            InlineFormatType::Bold,
-            InlineFormatType::Italic,
-        ])
+        Vec::from([InlineFormatType::Bold, InlineFormatType::Italic,])
     );
     model.replace_text(utf16("a"));
-    assert_eq!(
-        model.state.toggled_format_types,
-        Vec::new()
-    );
+    assert_eq!(model.state.toggled_format_types, Vec::new());
     model.undo();
     assert_eq!(
         model.state.toggled_format_types,
-        Vec::from([
-            InlineFormatType::Bold,
-            InlineFormatType::Italic,
-        ])
+        Vec::from([InlineFormatType::Bold, InlineFormatType::Italic,])
     );
 }

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -17,7 +17,6 @@
 use crate::tests::testutils_composer_model::cm;
 
 use crate::dom::nodes::{DomNode, TextNode};
-use crate::InlineFormatType;
 
 use crate::tests::testutils_conversion::utf16;
 
@@ -66,7 +65,7 @@ fn formatting_text_creates_previous_state() {
     let mut model = cm("hello {world}|!");
     assert!(model.previous_states.is_empty());
 
-    model.format(InlineFormatType::Bold);
+    model.bold();
     assert!(!model.previous_states.is_empty());
 }
 


### PR DESCRIPTION
* Add the possibility to toggle formatting with no selection without updating the current HTML, but saving a state instead.
* The state is cleared on selection changes.
* The state is restored if needed when using `undo`.
* Status for highlighted buttons in client is created regarding both this new state and the tags at the current position.

![Simulator Screen Recording - iPhone 13 - 2022-09-28 at 15 01 37](https://user-images.githubusercontent.com/80891108/192785319-63958461-1865-4a44-95b6-b3198b39d607.gif)
