### PR TITLE
Fix reversed_actions state when selecting a line break or right after it

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -51,16 +51,19 @@ where
         &mut self,
         range: &Range,
     ) -> HashSet<ComposerAction> {
-        let mut reversed_actions_sets = range
-            .leaves()
-            .map(|l| self.compute_reversed_actions(&l.node_handle));
-        let intersection = reversed_actions_sets.next().map(|set| {
-            reversed_actions_sets.fold(set, |set1, set2| {
-                set1.intersection(&set2).into_iter().cloned().collect()
-            })
-        });
-
-        if let Some(intersection) = intersection {
+        if let Some(intersection) = range.leaves().next().map(|l| {
+            range.leaves().fold(
+                self.compute_reversed_actions(&l.node_handle),
+                |set, leave| {
+                    set.intersection(
+                        &self.compute_reversed_actions(&leave.node_handle),
+                    )
+                    .into_iter()
+                    .cloned()
+                    .collect()
+                },
+            )
+        }) {
             intersection
         } else {
             HashSet::new()

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -53,12 +53,13 @@ where
     ) -> HashSet<ComposerAction> {
         if let Some(intersection) = range.leaves().next().map(|l| {
             range.leaves().fold(
+                // Init with reversed_actions from the first leave.
                 self.compute_reversed_actions(&l.node_handle),
+                // And intersect with the reversed_actions of all subsequent leaves.
                 |set, leave| {
                     set.intersection(
                         &self.compute_reversed_actions(&leave.node_handle),
                     )
-                    .into_iter()
                     .cloned()
                     .collect()
                 },

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -173,6 +173,24 @@ fn test_menu_updates_unindent() {
     );
 }
 
+#[test]
+fn selecting_line_break_inside_formatting_node_reversed_actions() {
+    let model = cm("<strong><em>aaa<br />{<br />}|bbb</em></strong>");
+    assert_eq!(
+        model.reversed_actions,
+        HashSet::from([ComposerAction::Bold, ComposerAction::Italic,])
+    );
+}
+
+#[test]
+fn selecting_after_a_line_break_inside_formatting_nodes_reversed_actions() {
+    let model = cm("<strong><em>aaa<br /><br />|bbb</em></strong>");
+    assert_eq!(
+        model.reversed_actions,
+        HashSet::from([ComposerAction::Bold, ComposerAction::Italic,])
+    );
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }


### PR DESCRIPTION
Fixes issues with the menu state when selecting line breaks or having the cursor next to a line break. 
Line breaks now behave like text nodes and lookup formatting nodes in their ancestors. 