### PR TITLE
fix(wysiwyg): Remove useless a `to_string` call + code simplification with `matches!`

### DIFF
--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -116,24 +116,15 @@ where
     }
 
     pub fn is_structure_node(&self) -> bool {
-        match self {
-            DomNode::Container(n) => n.is_structure_node(),
-            _ => false,
-        }
+        matches!(self, DomNode::Container(n) if n.is_structure_node())
     }
 
     pub fn is_formatting_node(&self) -> bool {
-        match self {
-            DomNode::Container(n) => n.is_formatting_node(),
-            _ => false,
-        }
+        matches!(self, DomNode::Container(n) if n.is_formatting_node())
     }
 
     pub(crate) fn is_placeholder_text_node(&self) -> bool {
-        match self {
-            DomNode::Text(n) => n.data().len() == 1 && n.data() == "\u{200b}",
-            _ => false,
-        }
+        matches!(self, DomNode::Text(n) if n.data().len() == 1 && n.data() == "\u{200b}")
     }
 
     pub(crate) fn has_only_placeholder_text_child(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -131,9 +131,7 @@ where
 
     pub(crate) fn is_placeholder_text_node(&self) -> bool {
         match self {
-            DomNode::Text(n) => {
-                n.data().len() == 1 && n.data().to_string() == "\u{200b}"
-            }
+            DomNode::Text(n) => n.data().len() == 1 && n.data() == "\u{200b}",
             _ => false,
         }
     }


### PR DESCRIPTION
This PR is twofold:

1. It removes a useless call to `to_string` (hence removing one memory allocation),
2. It simplify code with `matches!`.

Explanations for `matches!`:

```rust
match self {
    DomNode::Container(n) => n.is_structure_node(),
    _ => false,
}
```

is equivalent to:

```rust
match self {
    DomNode::Container(n) if n.is_structure_node() => true,
    _ => false,
}
```

which then can be used with `matches!` as:

```rust
matches!(DomNode::Container(n) if n.is_structure_node())
```