### PR TITLE
Fix unformatting multiple nodes at the same time

### DIFF
--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -16,7 +16,7 @@ use crate::dom::nodes::{ContainerNodeKind, DomNode};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{Dom, DomHandle, DomLocation, Range};
 use crate::{
-    ComposerAction, ComposerModel, ComposerUpdate, InlineFormatType, Location,
+    ComposerAction, ComposerModel, ComposerUpdate, InlineFormatType,
     UnicodeString,
 };
 use std::collections::HashMap;
@@ -222,22 +222,14 @@ where
         let mut reformat_from: Option<usize> = None;
         if let Some(location) = formatting_locations.first() {
             // Actual last node, find text to reformat after.
-            let (after_start, after_end) = self.safe_locations_from(
-                Location::from(end),
-                Location::from(end + location.length - location.end_offset),
-            );
-            if after_end > after_start {
-                reformat_to = Some(after_end);
+            if location.length - location.end_offset > 0 {
+                reformat_to = Some(end + location.length - location.end_offset);
             }
         }
         if let Some(location) = formatting_locations.last() {
             // Actual first node, find text to reformat before.
-            let (before_start, before_end) = self.safe_locations_from(
-                Location::from(start - location.start_offset),
-                Location::from(start),
-            );
-            if before_end > before_start {
-                reformat_from = Some(before_start);
+            if location.start_offset > 0 {
+                reformat_from = Some(start - location.start_offset);
             }
         }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -240,6 +240,13 @@ where
         matches!(self.kind, ContainerNodeKind::Formatting(_))
     }
 
+    pub(crate) fn is_formatting_node_of_type(
+        &self,
+        format_type: &InlineFormatType,
+    ) -> bool {
+        matches!(&self.kind, ContainerNodeKind::Formatting(f) if f == format_type)
+    }
+
     pub fn text_len(&self) -> usize {
         self.children.iter().map(|child| child.text_len()).sum()
     }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -123,6 +123,13 @@ where
         matches!(self, DomNode::Container(n) if n.is_formatting_node())
     }
 
+    pub fn is_formatting_node_of_type(
+        &self,
+        format_type: &InlineFormatType,
+    ) -> bool {
+        matches!(self, DomNode::Container(n) if n.is_formatting_node_of_type(format_type))
+    }
+
     pub(crate) fn is_placeholder_text_node(&self) -> bool {
         matches!(self, DomNode::Text(n) if n.data().len() == 1 && n.data() == "\u{200b}")
     }

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -203,3 +203,24 @@ fn formatting_again_removes_toggled_format_type() {
     model.bold();
     assert_eq!(model.state.toggled_format_types, Vec::new(),);
 }
+
+#[test]
+fn unformatting_consecutive_same_formatting_nodes() {
+    let mut model = cm("{<strong>Test</strong><strong> </strong><strong>test</strong><strong> test</strong>}|");
+    model.bold();
+    assert_eq!(tx(&model), "{Test test test}|");
+}
+
+#[test]
+fn unformatting_consecutive_same_formatting_nodes_with_line_break_in_between() {
+    let mut model = cm("{<strong>Test</strong><strong> </strong><strong>te<br />st</strong><strong> test</strong>}|");
+    model.bold();
+    assert_eq!(tx(&model), "{Test te<br />st test}|");
+}
+
+#[test]
+fn unformatting_consecutive_same_formatting_nodes_with_nested_node() {
+    let mut model = cm("{<strong>Test</strong><strong> </strong><strong>t<em>es</em>t</strong><strong> test</strong>}|");
+    model.bold();
+    assert_eq!(tx(&model), "{Test t<em>es</em>t test}|");
+}

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -212,7 +212,7 @@ fn unformatting_consecutive_same_formatting_nodes() {
 }
 
 #[test]
-fn unformatting_consecutive_same_formatting_nodes_with_line_break_in_between() {
+fn unformatting_consecutive_same_formatting_nodes_with_nested_line_break() {
     let mut model = cm("{<strong>Test</strong><strong> </strong><strong>te<br />st</strong><strong> test</strong>}|");
     model.bold();
     assert_eq!(tx(&model), "{Test te<br />st test}|");


### PR DESCRIPTION
Fixes issues (panics) when trying to unformat multiple consecutive node of the same type with nested node or line breaks inside