### PR TITLE
Display link href inside debug tree representation

### DIFF
--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -343,8 +343,15 @@ where
     S: UnicodeString,
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
+        let mut description = self.name.clone();
+        if let ContainerNodeKind::Link(url) = self.kind() {
+            description.push(" \"");
+            description.push(url.clone());
+            description.push("\"");
+        }
+
         let mut tree_part = self.tree_line(
-            self.name.clone(),
+            description,
             self.handle.raw().len(),
             continuous_positions.clone(),
         );

--- a/crates/wysiwyg/src/tests/test_to_tree.rs
+++ b/crates/wysiwyg/src/tests/test_to_tree.rs
@@ -79,3 +79,16 @@ fn br_within_text_shows_up_in_tree() {
 "#,
     );
 }
+
+#[test]
+fn link_href_shows_up_in_tree() {
+    let model = cm("Some <a href=\"https://matrix.org\">url|</a>");
+    assert_eq!(
+        model.state.dom.to_tree(),
+        r#"
+├>"Some "
+└>a "https://matrix.org"
+  └>"url"
+"#,
+    );
+}

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
         ScrollView {
             if let tree = tree {
                 Text(tree)
-                    .font(.system(.body, design: .monospaced))
+                    .font(.system(size: 11.0, weight: .regular, design: .monospaced))
                     .multilineTextAlignment(.leading)
             }
             if let sentMessage = sentMessage {


### PR DESCRIPTION
Allows displaying the href from link in the tree debug representation

<img src="https://user-images.githubusercontent.com/80891108/193237381-20a86c39-bfd7-4a3e-95cc-a689e92ee26c.png" width="250"/>
