### PR TITLE
Handle replacing text with newline characters

### DIFF
--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -265,6 +265,28 @@ fn multiple_spaces_between_text() {
     assert_eq!(tx(&model), "abc&nbsp;&nbsp;def ghi&nbsp;&nbsp; jkl|");
 }
 
+#[test]
+fn newline_characters_insert_br_tags() {
+    let mut model = cm("|");
+    replace_text(&mut model, "abc\ndef\nghi");
+    assert_eq!(tx(&model), "abc<br />def<br />ghi|");
+}
+
+#[test]
+fn leading_and_trailing_newline_characters_insert_br_tags() {
+    let mut model = cm("|");
+    replace_text(&mut model, "\nabc");
+    assert_eq!(tx(&model), "<br />abc|");
+
+    let mut model = cm("|");
+    replace_text(&mut model, "abc\n");
+    assert_eq!(tx(&model), "abc<br />|");
+
+    let mut model = cm("|");
+    replace_text(&mut model, "\nabc\n");
+    assert_eq!(tx(&model), "<br />abc<br />|");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -232,6 +232,21 @@ fn un_indent_nested_lists_with_remnants_works() {
     )
 }
 
+#[test]
+fn replacing_text_with_newline_characters_inserts_list_items() {
+    let mut model = cm("<ul><li>abc|</li></ul>");
+    replace_text(&mut model, "def\nghi");
+    assert_eq!(tx(&model), "<ul><li>abcdef</li><li>~ghi|</li></ul>");
+}
+
+#[test]
+#[ignore = "Should be fixed once ZWSP are always properly inserted into list items"]
+fn replacing_cross_list_item_selection_with_text_containing_newline_works() {
+    let mut model = cm("<ul><li>a{bc</li><li>~de}|f</li></ul>");
+    replace_text(&mut model, "ghi\njkl");
+    assert_eq!(tx(&model), "<ul><li>aghi</li><li>~jkl|f</li></ul>");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -167,3 +167,13 @@ fn undoing_enter_only_undoes_one() {
     model.undo();
     assert_eq!(tx(&model), "Test<br />|");
 }
+
+#[test]
+fn replacing_text_with_newlines_only_adds_one_to_undo_stack() {
+    let mut model = cm("abc|");
+    model.replace_text(utf16("def\nghi"));
+    model.replace_text(utf16("\njkl\n"));
+    model.undo();
+    model.undo();
+    assert_eq!(tx(&model), "abc|");
+}


### PR DESCRIPTION
Automatically replaces newline characters in replace_text with `<br />` or `<li>` depending on context. 

![Simulator Screen Recording - iPhone 13 - 2022-10-04 at 14 47 54](https://user-images.githubusercontent.com/80891108/193823363-82128a4c-cd06-44ea-8d93-1b4eea46978e.gif)

![Simulator Screen Recording - iPhone 13 - 2022-10-04 at 15 03 25](https://user-images.githubusercontent.com/80891108/193826309-8c794152-62b6-441f-a1e9-1407526de092.gif)

(second screen record contains an iOS selection issue around lists that is definitely not related to this change)
