### PR TITLE
Customisable Text Color To Support Dark Theme

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -104,7 +104,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
 }
 
 public extension WysiwygComposerView {
-    /// Sets the textColor of the WYSIWYG textView, if not used the default label UIColor is used.
+    /// Sets the textColor of the WYSIWYG textView, if not used the default value is Color.primary.
     func textColor(_ textColor: Color) -> Self {
         var newSelf = Self(
             content: content,

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -25,15 +25,18 @@ public struct WysiwygComposerView: UIViewRepresentable {
     public var replaceText: (NSAttributedString, NSRange, String) -> Bool
     public var select: (NSAttributedString, NSRange) -> Void
     public var didUpdateText: (UITextView) -> Void
+    public var textColor: UIColor
 
     public init(content: WysiwygComposerContent,
                 replaceText: @escaping (NSAttributedString, NSRange, String) -> Bool,
                 select: @escaping (NSAttributedString, NSRange) -> Void,
-                didUpdateText: @escaping (UITextView) -> Void) {
+                didUpdateText: @escaping (UITextView) -> Void,
+                textColor: UIColor = .label) {
         self.content = content
         self.replaceText = replaceText
         self.select = select
         self.didUpdateText = didUpdateText
+        self.textColor = textColor
     }
     
     public func makeUIView(context: Context) -> UITextView {
@@ -58,6 +61,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                  functionName: #function)
         uiView.apply(content)
         context.coordinator.didUpdateText(uiView)
+        uiView.textColor = textColor
     }
 
     public func makeCoordinator() -> Coordinator {
@@ -98,6 +102,18 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                      functionName: #function)
             select(textView.attributedText, textView.selectedRange)
         }
+    }
+}
+
+public extension WysiwygComposerView {
+    func textColor(_ textColor: UIColor) -> Self {
+        Self(
+            content: content,
+            replaceText: replaceText,
+            select: select,
+            didUpdateText: didUpdateText,
+            textColor: textColor
+        )
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -25,7 +25,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     public var replaceText: (NSAttributedString, NSRange, String) -> Bool
     public var select: (NSAttributedString, NSRange) -> Void
     public var didUpdateText: (UITextView) -> Void
-    private var textColor: UIColor = .label
+    private var textColor = Color.primary
 
     public init(content: WysiwygComposerContent,
                 replaceText: @escaping (NSAttributedString, NSRange, String) -> Bool,
@@ -59,7 +59,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                  functionName: #function)
         uiView.apply(content)
         context.coordinator.didUpdateText(uiView)
-        uiView.textColor = textColor
+        uiView.textColor = UIColor(textColor)
     }
 
     public func makeCoordinator() -> Coordinator {
@@ -112,7 +112,7 @@ public extension WysiwygComposerView {
             select: select,
             didUpdateText: didUpdateText
         )
-        newSelf.textColor = UIColor(textColor)
+        newSelf.textColor = textColor
         return newSelf
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -25,18 +25,16 @@ public struct WysiwygComposerView: UIViewRepresentable {
     public var replaceText: (NSAttributedString, NSRange, String) -> Bool
     public var select: (NSAttributedString, NSRange) -> Void
     public var didUpdateText: (UITextView) -> Void
-    public var textColor: UIColor
+    private var textColor: UIColor = .label
 
     public init(content: WysiwygComposerContent,
                 replaceText: @escaping (NSAttributedString, NSRange, String) -> Bool,
                 select: @escaping (NSAttributedString, NSRange) -> Void,
-                didUpdateText: @escaping (UITextView) -> Void,
-                textColor: UIColor = .label) {
+                didUpdateText: @escaping (UITextView) -> Void) {
         self.content = content
         self.replaceText = replaceText
         self.select = select
         self.didUpdateText = didUpdateText
-        self.textColor = textColor
     }
     
     public func makeUIView(context: Context) -> UITextView {
@@ -106,14 +104,15 @@ public struct WysiwygComposerView: UIViewRepresentable {
 }
 
 public extension WysiwygComposerView {
-    func textColor(_ textColor: UIColor) -> Self {
-        Self(
+    func textColor(_ textColor: Color) -> Self {
+        var newSelf = Self(
             content: content,
             replaceText: replaceText,
             select: select,
-            didUpdateText: didUpdateText,
-            textColor: textColor
+            didUpdateText: didUpdateText
         )
+        newSelf.textColor = UIColor(textColor)
+        return newSelf
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -104,6 +104,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
 }
 
 public extension WysiwygComposerView {
+    /// Sets the textColor of the WYSIWYG textView, if not used the default label UIColor is used.
     func textColor(_ textColor: Color) -> Self {
         var newSelf = Self(
             content: content,

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -298,7 +298,10 @@ private extension WysiwygComposerViewModel {
         if maximised {
             idealHeight = maxHeight
         } else {
-            idealHeight = compressedHeight
+            // This solves the slowdown caused by the "Publishing changes from within view updates" purple warning
+            DispatchQueue.main.async {
+                self.idealHeight = self.compressedHeight
+            }
         }
     }
     


### PR DESCRIPTION
Added a `textColor` variable inside the WysiwygComposerView that can be used to set programmatically at each update the color of the text.

By default the `textColor` variable is equal to `label` colour which is already dark theme responsive (black for light theme, white for dark theme).

The `textColor ` can either be customised in the init or using a view modifier in SwiftUI style.

Also fixed a concurrency bug that slowed down the loading of the view.

https://element-io.atlassian.net/jira/software/c/projects/PSU/boards/29?modal=detail&selectedIssue=PSU-848

EDIT: Removed the value from the init, now the `textColor` can only be changed through SwiftUI-like modifier function