### PR TITLE
[iOS] Fix text view height computation

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -181,14 +181,14 @@ public extension WysiwygComposerViewModel {
     ///
     /// - Parameter textView: The composer's text view.
     func didUpdateText(textView: UITextView) {
-        updateCompressedHeightIfNeeded(textView)
-
         // Reconciliate
         if textView.attributedText != content.attributed {
             Logger.viewModel.logDebug(["Reconciliate from \"\(textView.text ?? "")\" to \"\(content.plainText)\""],
                                       functionName: #function)
             textView.apply(content)
         }
+
+        updateCompressedHeightIfNeeded(textView)
     }
 }
 


### PR DESCRIPTION
Fixes the text view sometimes outputting wrong required height (most notably around trailing line breaks). This was due to the computation not taking into account the changes from reconciliating the content with the Rust model. 