### PR TITLE
[iOS] textColor modifier code improvement

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -107,12 +107,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
 public extension WysiwygComposerView {
     /// Sets the textColor of the WYSIWYG textView, if not used the default value is Color.primary.
     func textColor(_ textColor: Color) -> Self {
-        var newSelf = Self(
-            content: content,
-            replaceText: replaceText,
-            select: select,
-            didUpdateText: didUpdateText
-        )
+        var newSelf = self
         newSelf.textColor = textColor
         return newSelf
     }


### PR DESCRIPTION
Just realised that by using the init inside the modifier function, that would reset the state of the view on the default values, invalidating any previously used modifier on the view (even custom ones we might build and use in the future). 
The best approach is just to copy self, as it is since is a struct, and then change the value of the textColor.