### PR TITLE
Fix `replace_all_html` not moving the selection

### DIFF
--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -18,6 +18,7 @@ namespace wysiwyg_composer {
 
 interface ComposerModel {
     ComposerUpdate replace_all_html(string html);
+    ComposerUpdate clear();
     ComposerUpdate select(u32 start_utf16_codeunit, u32 end_utf16_codeunit);
     ComposerUpdate replace_text(string new_text);
     ComposerUpdate replace_text_in(string new_text, u32 start, u32 end);

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -86,6 +86,8 @@ where
         match dom {
             Ok(dom) => {
                 self.state.dom = dom;
+                self.state.start = Location::from(self.state.dom.text_len());
+                self.state.end = self.state.start;
                 self.previous_states.clear();
                 self.next_states.clear();
                 self.create_update_replace_all()

--- a/crates/wysiwyg/src/tests/test_replace_all_html.rs
+++ b/crates/wysiwyg/src/tests/test_replace_all_html.rs
@@ -16,11 +16,20 @@ use widestring::Utf16String;
 
 use crate::{tests::testutils_composer_model::tx, ComposerModel};
 
+use super::testutils_composer_model::cm;
+
 #[test]
 fn replace_all_html() {
     let mut model = ComposerModel::new();
     model.replace_all_html(&Utf16String::from("content"));
-    assert_eq!(tx(&model), "|content");
+    assert_eq!(tx(&model), "content|");
+}
+
+#[test]
+fn replace_all_html_moves_cursor_to_the_end() {
+    let mut model = cm("abc|");
+    model.replace_all_html(&"content".into());
+    assert_eq!(tx(&model), "content|");
 }
 
 #[test]

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -130,10 +130,18 @@ public class WysiwygComposerViewModel: ObservableObject {
         applyUpdate(update)
     }
 
+    /// Sets given HTML as the current content of the composer.
+    ///
+    /// - Parameters:
+    ///   - html: HTML content to apply
+    public func setHtmlContent(_ html: String) {
+        let update = model.replaceAllHtml(html: html)
+        applyUpdate(update)
+    }
+
     /// Clear the content of the composer.
     public func clearContent() {
-        model = newComposerModel()
-        content = WysiwygComposerContent()
+        applyUpdate(model.clear())
     }
 
     /// Returns a textual representation of the composer model as a tree.


### PR DESCRIPTION
* Fixes the `replace_all_html` so it moves the selection to the end of the content.
* Enable and use the `clear` variant in iOS lib.
* Add a public API in the iOS lib to allow the hosting application to set the HTML content.