### PR TITLE
Restrict the Cypress tests that use clipboard to Electron browser

### DIFF
--- a/platforms/web/cypress/e2e/clipboard/cut.spec.ts
+++ b/platforms/web/cypress/e2e/clipboard/cut.spec.ts
@@ -19,7 +19,7 @@ limitations under the License.
 describe('Cut', () => {
     const editor = '.editor:not([disabled])[contenteditable="true"]';
 
-    it('remove text that is cut to clipboard', () => {
+    it('remove text that is cut to clipboard', { browser: 'electron' }, () => {
         cy.visit('/');
         cy.get(editor).type('firstREMOVEME');
         cy.setSelection(editor, 5, 13);

--- a/platforms/web/cypress/e2e/clipboard/paste.spec.ts
+++ b/platforms/web/cypress/e2e/clipboard/paste.spec.ts
@@ -19,24 +19,36 @@ limitations under the License.
 describe('Paste', () => {
     const editor = '.editor:not([disabled])[contenteditable="true"]';
 
-    it('should display pasted text after we type', () => {
-        cy.visit('/');
-        cy.get(editor).type('BEFORE');
-        cy.window().its('navigator.clipboard').invoke('writeText', 'pasted');
-        cy.get(editor).focus();
-        cy.document().invoke('execCommand', 'paste');
-        cy.get(editor).type('AFTER');
-        cy.get(editor).contains(/^BEFOREpastedAFTER/);
-    });
+    it(
+        'should display pasted text after we type',
+        { browser: 'electron' },
+        () => {
+            cy.visit('/');
+            cy.get(editor).type('BEFORE');
+            cy.window()
+                .its('navigator.clipboard')
+                .invoke('writeText', 'pasted');
+            cy.get(editor).focus();
+            cy.document().invoke('execCommand', 'paste');
+            cy.get(editor).type('AFTER');
+            cy.get(editor).contains(/^BEFOREpastedAFTER/);
+        },
+    );
 
-    it('should convert pasted newlines into BRs', () => {
-        cy.visit('/');
-        cy.window().its('navigator.clipboard').invoke('writeText', 'aa\nbb');
-        cy.get(editor).focus();
-        cy.document().invoke('execCommand', 'paste');
-        cy.get(editor)
-            .invoke('html')
-            .then((html) => expect(html).to.equal('aa<br>bb<br>'));
-        // (Note the extra BR is always added at the end)
-    });
+    it(
+        'should convert pasted newlines into BRs',
+        { browser: 'electron' },
+        () => {
+            cy.visit('/');
+            cy.window()
+                .its('navigator.clipboard')
+                .invoke('writeText', 'aa\nbb');
+            cy.get(editor).focus();
+            cy.document().invoke('execCommand', 'paste');
+            cy.get(editor)
+                .invoke('html')
+                .then((html) => expect(html).to.equal('aa<br>bb<br>'));
+            // (Note the extra BR is always added at the end)
+        },
+    );
 });


### PR DESCRIPTION
Since they use commands that don't work in Cypress in other browsers.