### PR TITLE
Web: Add formatting state

### DIFF
--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -25,7 +25,6 @@ export function processInput(
 ) {
     if (e instanceof ClipboardEvent) {
         const data = e.clipboardData?.getData('text/plain') ?? '';
-        console.log(data);
         return action(composerModel.replace_text(data), 'paste');
     }
 

--- a/platforms/web/lib/constants.ts
+++ b/platforms/web/lib/constants.ts
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { FORMATTING_ACTIONS } from './constants';
-
-export type BlockType = InputEvent['inputType'] | 'formatInlineCode' | 'clear';
-
-export type WysiwygInputEvent =
-    | ClipboardEvent
-    | (InputEvent & { inputType: BlockType });
-
-export type FormattingActions = typeof FORMATTING_ACTIONS[number];
-
-export type FormattingState = 'enabled' | 'reversed' | 'disabled';
-
-export type FormattingStates = Record<FormattingActions, FormattingState>;
+export const FORMATTING_ACTIONS = [
+    'bold',
+    'italic',
+    'strikeThrough',
+    'underline',
+    'undo',
+    'redo',
+    'orderedList',
+    'unorderedList',
+    'inlineCode',
+    'clear',
+] as const;

--- a/platforms/web/lib/useFormattingActions.ts
+++ b/platforms/web/lib/useFormattingActions.ts
@@ -16,32 +16,33 @@ limitations under the License.
 
 import { RefObject, useMemo } from 'react';
 
-import { BlockType } from './types';
+import { BlockType, FormattingActions } from './types';
 import { sendWysiwygInputEvent } from './useListeners';
 
 export function useFormattingActions(editorRef: RefObject<HTMLElement | null>) {
-    const formattingActions = useMemo(() => {
-        // The formatting action like inline code doesn't have an input type
-        // Safari does not keep the inputType in an input event when the input
-        // event is fired manually, so we send a custom event and we do not use
-        // the browser input event handling
-        const sendEvent = (blockType: BlockType) =>
-            editorRef.current &&
-            sendWysiwygInputEvent(editorRef.current, blockType);
+    const formattingActions: Record<FormattingActions, () => void> =
+        useMemo(() => {
+            // The formatting action like inline code doesn't have an input type
+            // Safari does not keep the inputType in an input event
+            // when the input event is fired manually, so we send a custom event
+            // and we do not use the browser input event handling
+            const sendEvent = (blockType: BlockType) =>
+                editorRef.current &&
+                sendWysiwygInputEvent(editorRef.current, blockType);
 
-        return {
-            bold: () => sendEvent('formatBold'),
-            italic: () => sendEvent('formatItalic'),
-            strikeThrough: () => sendEvent('formatStrikeThrough'),
-            underline: () => sendEvent('formatUnderline'),
-            undo: () => sendEvent('historyUndo'),
-            redo: () => sendEvent('historyRedo'),
-            orderedList: () => sendEvent('insertOrderedList'),
-            unorderedList: () => sendEvent('insertUnorderedList'),
-            inlineCode: () => sendEvent('formatInlineCode'),
-            clear: () => sendEvent('clear'),
-        };
-    }, [editorRef]);
+            return {
+                bold: () => sendEvent('formatBold'),
+                italic: () => sendEvent('formatItalic'),
+                strikeThrough: () => sendEvent('formatStrikeThrough'),
+                underline: () => sendEvent('formatUnderline'),
+                undo: () => sendEvent('historyUndo'),
+                redo: () => sendEvent('historyRedo'),
+                orderedList: () => sendEvent('insertOrderedList'),
+                unorderedList: () => sendEvent('insertUnorderedList'),
+                inlineCode: () => sendEvent('formatInlineCode'),
+                clear: () => sendEvent('clear'),
+            };
+        }, [editorRef]);
 
     return formattingActions;
 }

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -28,7 +28,7 @@ import {
     refreshComposerView,
     replaceEditor,
 } from '../dom';
-import { FormattingStates, BlockType, WysiwygInputEvent } from '../types';
+import { BlockType, WysiwygInputEvent } from '../types';
 import { TestUtilities } from '../useTestCases/types';
 import { getDefaultFormattingStates } from './utils';
 
@@ -82,7 +82,7 @@ export function handleKeyDown(e: KeyboardEvent, editor: HTMLElement) {
 function getFormattingState(menuStateUpdate: MenuStateUpdate) {
     const reversedActions = menuStateUpdate.reversed_actions;
     const disabledActions = menuStateUpdate.disabled_actions;
-    const states: FormattingStates = getDefaultFormattingStates();
+    const states = getDefaultFormattingStates();
 
     const computeActions = (
         actions: ComposerActions,
@@ -115,6 +115,9 @@ function getFormattingState(menuStateUpdate: MenuStateUpdate) {
                     break;
                 case ComposerAction.UnorderedList:
                     states.unorderedList = value;
+                    break;
+                case ComposerAction.InlineCode:
+                    states.inlineCode = value;
                     break;
                 default:
                     break;

--- a/platforms/web/lib/useListeners/utils.ts
+++ b/platforms/web/lib/useListeners/utils.ts
@@ -14,16 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { FORMATTING_ACTIONS } from './constants';
+import { FORMATTING_ACTIONS } from '../constants';
+import { FormattingState, FormattingActions } from '../types';
 
-export type BlockType = InputEvent['inputType'] | 'formatInlineCode' | 'clear';
-
-export type WysiwygInputEvent =
-    | ClipboardEvent
-    | (InputEvent & { inputType: BlockType });
-
-export type FormattingActions = typeof FORMATTING_ACTIONS[number];
-
-export type FormattingState = 'enabled' | 'reversed' | 'disabled';
-
-export type FormattingStates = Record<FormattingActions, FormattingState>;
+export function getDefaultFormattingStates() {
+    return FORMATTING_ACTIONS.reduce<
+        Record<FormattingActions, FormattingState>
+    >((acc, action) => {
+        acc[action] = 'enabled';
+        return acc;
+    }, {} as Record<FormattingActions, FormattingState>);
+}

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -34,7 +34,7 @@ function useEditorFocus(
         if (isAutoFocusEnabled) {
             // TODO remove this workaround
             const id = setTimeout(() => editorRef.current?.focus(), 200);
-            return () => clearInterval(id);
+            return () => clearTimeout(id);
         }
     }, [editorRef, isAutoFocusEnabled]);
 }
@@ -65,7 +65,6 @@ function useEditor() {
 
 type WysiwygProps = {
     isAutoFocusEnabled?: boolean;
-    onChange?: (content: string) => void;
 };
 
 export function useWysiwyg(wysiwygProps?: WysiwygProps) {
@@ -77,13 +76,14 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
         ref,
         composerModel,
     );
-    useListeners(
+
+    const { content, formattingStates } = useListeners(
         ref,
         modelRef,
         composerModel,
         testUtilities,
-        wysiwygProps?.onChange,
     );
+
     const formattingActions = useFormattingActions(ref);
     useEditorFocus(ref, wysiwygProps?.isAutoFocusEnabled);
 
@@ -91,6 +91,8 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
         ref,
         isWysiwygReady: Boolean(composerModel),
         wysiwyg: formattingActions,
+        content,
+        formattingStates,
         debug: {
             modelRef,
             testRef,

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -30,20 +30,31 @@ type ButtonProps = {
     onClick: MouseEventHandler<HTMLButtonElement>;
     imagePath: string;
     alt: string;
+    state: 'enabled' | 'disabled' | 'reversed';
 };
 
-function Button({ onClick, imagePath, alt }: ButtonProps) {
+function Button({ onClick, imagePath, alt, state }: ButtonProps) {
+    const isReversed = state === 'reversed';
+    const isDisabled = state === 'disabled';
     return (
-        <button type="button" onClick={onClick}>
+        <button
+            type="button"
+            onClick={onClick}
+            style={{
+                ...(isReversed && { backgroundColor: 'lightgray' }),
+                ...(isDisabled && { backgroundColor: 'firebrick' }),
+            }}
+        >
             <img alt={alt} src={imagePath} />
         </button>
     );
 }
 
 function App() {
-    const { ref, isWysiwygReady, wysiwyg, debug } = useWysiwyg({
-        isAutoFocusEnabled: true,
-    });
+    const { ref, isWysiwygReady, wysiwyg, formattingStates, debug } =
+        useWysiwyg({
+            isAutoFocusEnabled: true,
+        });
 
     return (
         <div className="wrapper">
@@ -54,46 +65,55 @@ function App() {
                             onClick={wysiwyg.undo}
                             alt="undo"
                             imagePath={undoImage}
+                            state={formattingStates.undo}
                         />
                         <Button
                             onClick={wysiwyg.redo}
                             alt="redo"
                             imagePath={redoImage}
+                            state={formattingStates.redo}
                         />
                         <Button
                             onClick={wysiwyg.bold}
                             alt="bold"
                             imagePath={boldImage}
+                            state={formattingStates.bold}
                         />
                         <Button
                             onClick={wysiwyg.italic}
                             alt="italic"
                             imagePath={italicImage}
+                            state={formattingStates.italic}
                         />
                         <Button
                             onClick={wysiwyg.underline}
                             alt="underline"
                             imagePath={underlineImage}
+                            state={formattingStates.underline}
                         />
                         <Button
                             onClick={wysiwyg.strikeThrough}
                             alt="strike through"
                             imagePath={strikeTroughImage}
+                            state={formattingStates.strikeThrough}
                         />
                         <Button
                             onClick={wysiwyg.unorderedList}
                             alt="list unordered"
                             imagePath={listUnorderedImage}
+                            state={formattingStates.unorderedList}
                         />
                         <Button
                             onClick={wysiwyg.orderedList}
                             alt="list ordered"
                             imagePath={listOrderedImage}
+                            state={formattingStates.orderedList}
                         />
                         <Button
                             onClick={wysiwyg.inlineCode}
                             alt="inline code"
                             imagePath={listOrderedImage}
+                            state={formattingStates.inlineCode}
                         />
                         <button type="button" onClick={(e) => wysiwyg.clear()}>
                             clear

--- a/platforms/web/tsconfig.json
+++ b/platforms/web/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "ESNext",
         "useDefineForClassFields": true,
         "lib": ["DOM", "DOM.Iterable", "ESNext"],
-        "allowJs": true,
+        "allowJs": false,
         "skipLibCheck": true,
         "esModuleInterop": false,
         "allowSyntheticDefaultImports": true,

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -21,13 +21,15 @@ import dts from 'vite-plugin-dts';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     plugins: [
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         react(),
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         dts({
-            include: ['lib/useWysiwyg.ts'],
-            insertTypesEntry: true,
+            include: ['lib/useWysiwyg.ts', 'lib/types.ts', 'lib/constants.ts'],
+            rollupTypes: true,
         }),
     ],
     test: {


### PR DESCRIPTION
Multiple things here:

- I removed the `onChange` handler and instead I return `content` in the `useWysiwyg` hook. It fits more the react _way_
- The hook returns `formattingStates` which is an object which contains the `formattingState` of all buttons
- I change a bit the typescript generation of the library to make work the complex type when the library is used. But it's still very febrile
- Remove remaining console.log
- Fix a call of `setInterval` instead of `setTimeout`