### PR TITLE
Allow formatting in empty composer

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -78,6 +78,8 @@ where
                 .collect()
         }) {
             intersection
+        } else if self.state.dom.document().children().is_empty() {
+            HashSet::from_iter(toggled_format_actions.into_iter())
         } else {
             HashSet::new()
         }

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -25,6 +25,9 @@ where
         start: Location,
         end: Location,
     ) -> ComposerUpdate<S> {
+        if self.state.start == start && self.state.end == end {
+            return ComposerUpdate::keep();
+        }
         self.state.toggled_format_types.clear();
         self.state.start = start;
         self.state.end = end;

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -14,9 +14,11 @@
 
 use crate::tests::testutils_composer_model::{cm, tx};
 use crate::tests::testutils_conversion::utf16;
+use widestring::Utf16String;
 
-use crate::InlineFormatType;
+use crate::InlineFormatType::Bold;
 use crate::Location;
+use crate::{ComposerModel, InlineFormatType};
 
 #[test]
 fn selecting_and_bolding_multiple_times() {
@@ -223,4 +225,19 @@ fn unformatting_consecutive_same_formatting_nodes_with_nested_node() {
     let mut model = cm("{<strong>Test</strong><strong> </strong><strong>t<em>es</em>t</strong><strong> test</strong>}|");
     model.bold();
     assert_eq!(tx(&model), "{Test t<em>es</em>t test}|");
+}
+
+#[test]
+fn format_empty_model_applies_formatting() {
+    let mut model = ComposerModel::<Utf16String>::new();
+    model.bold();
+    assert!(model.state.toggled_format_types.contains(&Bold));
+}
+
+#[test]
+fn changing_selection_to_same_doesnt_removes_formatting_state() {
+    let mut model = cm("AAA | BBB");
+    model.bold();
+    model.select(Location::from(4), Location::from(4));
+    assert!(model.state.toggled_format_types.contains(&Bold));
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -113,8 +113,7 @@ class EditorEditText : TextInputEditText {
             val result = update?.let { inputProcessor.processUpdate(it) }
 
             if (result != null) {
-                editableText.clear()
-                editableText.replace(0, editableText.length, result.text)
+                setTextInternal(result.text)
                 setSelectionFromComposerUpdate(result.selection.first, result.selection.last)
             } else {
                 super.setText(text, type)
@@ -122,13 +121,19 @@ class EditorEditText : TextInputEditText {
         }
     }
 
+    private fun setTextInternal(text: CharSequence?) {
+        beginBatchEdit()
+        editableText.clear()
+        editableText.replace(0, editableText.length, text)
+        endBatchEdit()
+    }
+
     override fun append(text: CharSequence?, start: Int, end: Int) {
         val update = inputProcessor.processInput(EditorInputAction.InsertText(text.toString()))
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, end, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.first, result.selection.last)
         } else {
             super.append(text, start, end)
@@ -136,14 +141,11 @@ class EditorEditText : TextInputEditText {
     }
 
     fun toggleInlineFormat(inlineFormat: InlineFormat): Boolean {
-        val (start, end) = inputConnection?.getCurrentComposition() ?: (0 to 0)
-        inputProcessor.updateSelection(editableText, start, end)
         val update = inputProcessor.processInput(EditorInputAction.ApplyInlineFormat(inlineFormat))
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.first, result.selection.last)
         }
         return result != null
@@ -154,8 +156,7 @@ class EditorEditText : TextInputEditText {
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.first, result.selection.last)
         }
     }
@@ -165,8 +166,7 @@ class EditorEditText : TextInputEditText {
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.last)
         }
     }
@@ -176,8 +176,7 @@ class EditorEditText : TextInputEditText {
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.last)
         }
     }
@@ -187,8 +186,7 @@ class EditorEditText : TextInputEditText {
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.last)
         }
     }
@@ -198,8 +196,7 @@ class EditorEditText : TextInputEditText {
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
-            editableText.clear()
-            editableText.replace(0, editableText.length, result.text)
+            setTextInternal(result.text)
             setSelectionFromComposerUpdate(result.selection.last)
         }
     }


### PR DESCRIPTION
Also prevent selecting the same cursor position from resetting menu state. 
Fixes for Android included too.