### PR TITLE
[Android] Fix selection after enter key code

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
@@ -144,6 +144,7 @@ class InterceptInputConnection(
                         beginBatchEdit()
                         if (result != null) {
                             editable.replace(0, editable.length, result.text)
+                            setSelectionOnEditable(editable, result.selection.last)
                         } else {
                             editable.replace(start, end, "\n")
                         }


### PR DESCRIPTION
Selection wasn't updated with the `ComposerUpdate`'s result selection values when enter key was pressed on a hardware keyboard on Android.