### PR TITLE
[Docs] Add sections and headings to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ Get the prerequisites for each platform by reading the READMEs for them:
 * WASM/JavaScript:
   [bindings/wysiwyg-wasm/README.md](bindings/wysiwyg-wasm/README.md)
 
-* Kotlin/Android:
-  [bindings/wysiwyg-ffi/README.md#android](bindings/wysiwyg-ffi/README.md#android)
-
-* Swift/iOS:
-  [bindings/wysiwyg-ffi/README.md#ios](bindings/wysiwyg-ffi/README.md#ios)
+* Android/Kotlin or iOS/Swift:
+  [bindings/wysiwyg-ffi/README.md](bindings/wysiwyg-ffi/README.md)
 
 Now, to build all the bindings, try:
 


### PR DESCRIPTION
- Extract platform agnostic Rust setup instructions to the top of the instructions
- Add headings to break up the content

Note: I haven't made any changes to the iOS docs but they might benefit from some of the same.