### PR TITLE
[Android] Fix formatting not being disabled when using hardware keyboard

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/InterceptInputConnection.kt
@@ -126,6 +126,7 @@ class InterceptInputConnection(
                             val selectionLength = end-start
                             beginBatchEdit()
                             if (result != null) {
+                                editable.clear()
                                 editable.replace(0, editable.length, result.text)
                             } else {
                                 editable.replace(start, end, newText)


### PR DESCRIPTION
The problem was the text contents of the `Editable` were being replaced, but the previous spans weren't being removed.