### PR TITLE
Fix replacing first line with line break

### DIFF
--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{ComposerModel, Location};
 use widestring::Utf16String;
 
 use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
 use crate::tests::testutils_conversion::utf16;
-use crate::{ComposerModel, Location};
 
 #[test]
 fn typing_a_character_into_an_empty_box_appends_it() {

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -144,6 +144,13 @@ fn can_backspace_to_beginning_after_making_a_line() {
     assert_eq!(tx(&model), "|");
 }
 
+#[test]
+fn test_replace_text_in_first_line_with_line_break() {
+    let mut model = cm("{AAA}|<br />BBB");
+    model.enter();
+    assert_eq!(tx(&model), "<br />|<br />BBB");
+}
+
 #[ignore] // TODO: backspace_merges_empty_text_nodes
 #[test]
 fn backspace_merges_empty_text_nodes() {


### PR DESCRIPTION
When calling `ComposerModel.enter()` in this situation, what happens internally is:
```
// Clear selection then enter.
self.do_replace_text_in("".into(), s, e);
self.do_enter() // This call is recursive
```

Which turns the tree into:
```
├>""
├>br
└>"BBB"
```
And when we then ask for nodes in range [0,0] both the first empty TextNode and the line break appear as leaf nodes in the index 0 of the Dom.