### PR TITLE
Fix inserting a new line before a new line at index 0 crashes

### DIFF
--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -278,8 +278,20 @@ where
                         (1, 1) => {
                             // Cursor is after line break, no need to delete
                         }
+                        (0, 0) => {
+                            let node =
+                                DomNode::new_text(new_text.clone().into());
+                            action_list.push(DomAction::add_node(
+                                loc.node_handle.parent_handle(),
+                                loc.node_handle.index_in_parent(),
+                                node,
+                            ));
+                        }
                         _ => panic!(
-                            "Should not get a range at start of a line break!"
+                            "Tried to insert text into a line break with offset != 0 or 1. \
+                            Start offset: {}, end offset: {}",
+                            loc.start_offset,
+                            loc.end_offset,
                         ),
                     }
                     if start >= loc.position && end == loc.position + 1 {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -278,12 +278,17 @@ where
                 panic!("Can't insert into a non-text node!")
             }
             DomNode::LineBreak(_) => {
-                assert!(
-                    offset == 1,
-                    "Attempting to insert after a line break, but the offset \
-                    into it was not 1."
-                );
-                Where::After
+                if offset == 0 {
+                    Where::Before
+                } else if offset == 1 {
+                    Where::After
+                } else {
+                    panic!(
+                        "Attempting to insert a new line into a new line node, but offset wasn't \
+                        either 0 or 1: {}", 
+                        offset
+                    );
+                }
             }
             DomNode::Text(n) => {
                 if offset == 0 {
@@ -394,13 +399,13 @@ impl Display for ItemNode {
 mod test {
     use widestring::Utf16String;
 
-    use super::*;
-
     use crate::dom::nodes::dom_node::DomNode;
     use crate::dom::nodes::TextNode;
     use crate::tests::testutils_composer_model::cm;
     use crate::tests::testutils_conversion::utf16;
     use crate::tests::testutils_dom::{a, b, dom, i, i_c, tn};
+
+    use super::*;
 
     // Creation and handles
 

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -296,12 +296,16 @@ fn leading_and_trailing_newline_characters_insert_br_tags() {
 }
 
 #[test]
-fn inserting_a_new_line_before_a_new_line_works() {
+fn inserting_a_new_line_and_text_before_a_new_line_works() {
     let mut model = cm("|{AAA}");
     model.enter();
     model.select(Location::from(0), Location::from(0));
+    // Inserting a line break at index 0 (no text node before it) can cause issues
     model.enter();
-    assert_eq!(tx(&model), "<br />|<br />");
+    model.select(Location::from(0), Location::from(0));
+    // Inserting text before a line break with no text node before it is a special case too
+    model.replace_text("Test".into());
+    assert_eq!(tx(&model), "Test|<br /><br />");
 }
 
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -295,6 +295,15 @@ fn leading_and_trailing_newline_characters_insert_br_tags() {
     assert_eq!(tx(&model), "<br />abc<br />|");
 }
 
+#[test]
+fn inserting_a_new_line_before_a_new_line_works() {
+    let mut model = cm("|{AAA}");
+    model.enter();
+    model.select(Location::from(0), Location::from(0));
+    model.enter();
+    assert_eq!(tx(&model), "<br />|<br />");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }


### PR DESCRIPTION
Solved 2 corner cases:
* Inserting a new line before a new line with no TextNode before it.
* Inserting text before a new line when there was no TextNode before it.