### PR TITLE
feat(wasm): Add a `dev-build` NPM script

### DIFF
--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -10,6 +10,14 @@ name = "wysiwyg-wasm"
 version = "0.1.0"
 rust-version = "1.60"
 
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ['-O', '-g']
+
+[package.metadata.wasm-pack.profile.profiling.wasm-bindgen]
+debug-js-glue = false
+demangle-name-section = true
+dwarf-debug-info = true
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-Oz']
 

--- a/bindings/wysiwyg-wasm/README.md
+++ b/bindings/wysiwyg-wasm/README.md
@@ -41,3 +41,12 @@ async function run() {
 run();
 </script>
 ```
+
+## Profiling
+
+To generate a debugging/profiling Wasm module, use the following command
+instead of `npm run build`:
+
+```sh
+$ npm run dev-build
+```

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -34,7 +34,8 @@
         "node": ">= 10"
     },
     "scripts": {
-        "build": "RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target web --out-name wysiwyg --out-dir ./pkg",
+        "dev-build": "wasm-pack build --profiling --target web --out-name wysiwyg --out-dir ./pkg",
+        "build": "RUSTFLAGS='-C opt-level=s' wasm-pack build --release --target web --out-name wysiwyg --out-dir ./pkg",
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig ."
     }


### PR DESCRIPTION
This patch adds a new NPM script: `dev-build`, which will build a “debug“/“profiling” build, instead of an optimized, small, no debug symbol, build. This is helpful when trying to debug something.