### PR TITLE
feat(wasm): Call a `start` function when a module is instantiated

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -17,15 +17,13 @@ use std::collections::VecDeque;
 use wasm_bindgen::prelude::*;
 use widestring::Utf16String;
 
-#[wasm_bindgen]
-pub fn init_panic_hook() {
+#[wasm_bindgen(start)]
+pub fn start() {
     console_error_panic_hook::set_once();
 }
 
 #[wasm_bindgen]
 pub fn new_composer_model() -> ComposerModel {
-    init_panic_hook();
-
     ComposerModel {
         inner: wysiwyg::ComposerModel::new(),
     }
@@ -37,8 +35,6 @@ pub fn new_composer_model_from_html(
     start_utf16_codeunit: u32,
     end_utf16_codeunit: u32,
 ) -> ComposerModel {
-    init_panic_hook();
-
     ComposerModel {
         inner: wysiwyg::ComposerModel::<Utf16String>::from_html(
             html,


### PR DESCRIPTION
By using `wasm_bindgen(start)`, we ensure that the `start` function is called everytime a Wasm module is instantiated. It means that we are sure that `console_error_panic_hook::set_once` will be called… once, and only once per Wasm instance.