### PR TITLE
[Android] Refactor to consolidate hardware/software key handling

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -39,7 +39,7 @@ class EditorEditTextInputTests {
     @get:Rule
     val scenarioRule = ActivityScenarioRule(TestActivity::class.java)
 
-    private val ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    private val ipsum = "Lorem Ipsum is simply dummy text of the printing and typesetting industry."
 
     init {
         AccessibilityChecks.enable()

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ImeActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ImeActions.kt
@@ -5,7 +5,6 @@ import android.view.inputmethod.EditorInfo
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.InterceptInputConnection
 import org.hamcrest.Matcher
 
@@ -68,7 +67,7 @@ object Ime {
             if (view == null) return
             val editorInfo = EditorInfo()
             val inputConnection = view.onCreateInputConnection(editorInfo)
-            (inputConnection as? InterceptInputConnection)?.backspace()
+            (inputConnection as? InterceptInputConnection)?.onHardwareBackspaceKey()
         }
     }
 
@@ -126,9 +125,7 @@ object Ime {
             if (view == null) return
             val editorInfo = EditorInfo()
             val inputConnection = view.onCreateInputConnection(editorInfo) as? InterceptInputConnection ?: return
-            val end = inputConnection.getCurrentComposition().second
-            inputConnection.setComposingRegion(end, end)
-            inputConnection.commitText("\n", 1)
+            inputConnection.onHardwareEnterKey()
         }
 
     }


### PR DESCRIPTION
## What?
Ensure that the logic triggered by hardware keys is shared as much as possible with the logic triggered by software keys.

_Note: although some logic is now shared, this is achieved by imitating the software keyboard's interactions with the `InputConnection`. Hence it is by no means a perfect solution and behaviour may still vary between input types._ 

[`PSU-907`](https://element-io.atlassian.net/browse/PSU-907)

## Why?
Handling hardware and software keys separately has a few risks:
- manual testing in an emulator using a computer keyboard may not reflect the true behaviour when using a touch screen input.
- the surface area for bugs is greater.
