### PR TITLE
[Android] extract composer index mapping, re-organize Android lib code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "uniffi",
  "uniffi_build",
@@ -1235,7 +1235,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wysiwyg"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "html-escape",
  "html5ever",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -7,7 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import com.google.android.material.textfield.TextInputLayout
 import io.element.android.wysiwyg.EditorEditText
-import io.element.android.wysiwyg.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.poc.databinding.ViewRichTextEditorBinding
 import uniffi.wysiwyg_composer.ComposerAction
 import uniffi.wysiwyg_composer.MenuState

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -51,6 +51,10 @@ android {
         // Disables animations during instrumented tests you run from the command line…
         // This property does not affect tests that you run using Android Studio.”
         animationsDisabled = true
+
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 
     ndkVersion = "22.1.7171670"
@@ -72,6 +76,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.test.espresso:espresso-accessibility:3.4.0'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.8'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -21,7 +21,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
 import io.element.android.wysiwyg.EditorEditText
-import io.element.android.wysiwyg.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.spans.OrderedListSpan
 import io.element.android.wysiwyg.test.utils.EditorActions
 import io.element.android.wysiwyg.test.utils.ImeActions
@@ -112,10 +112,11 @@ class EditorEditTextInputTests {
     @FlakyTest(detail = "Sometimes the pressKey event doesn't reach the view.")
     fun testHardwareKeyMovementNotIntercepted() {
         onView(withId(R.id.rich_text_edit_text))
-            .perform(ImeActions.setComposingText("Test"))
-            .perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
+            .perform(typeText("Test"))
             .perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
             .check(matches(selectionIsAt(3)))
+            .perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
+            .check(matches(selectionIsAt(2)))
     }
 
     @Test

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -5,7 +5,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import io.element.android.wysiwyg.EditorEditText
-import io.element.android.wysiwyg.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import org.hamcrest.Matcher
 
 object Editor {

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ImeActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ImeActions.kt
@@ -5,7 +5,7 @@ import android.view.inputmethod.EditorInfo
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import io.element.android.wysiwyg.InterceptInputConnection
+import io.element.android.wysiwyg.inputhandlers.InterceptInputConnection
 import org.hamcrest.Matcher
 
 object Ime {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -247,7 +247,7 @@ class EditorEditText : TextInputEditText {
     }
 
     private fun setSelectionFromComposerUpdate(start: Int, end: Int = start) {
-        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditText(start, end, editableText)
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
         setSelection(newStart, newEnd)
     }
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -1,6 +1,5 @@
 package io.element.android.wysiwyg
 
-import android.R
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -13,13 +12,14 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
-import androidx.core.text.getSpans
 import com.google.android.material.textfield.TextInputEditText
-import io.element.android.wysiwyg.spans.HtmlToSpansParser
+import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.InputProcessor
+import io.element.android.wysiwyg.inputhandlers.InterceptInputConnection
+import io.element.android.wysiwyg.utils.EditorIndexMapper
 import uniffi.wysiwyg_composer.MenuState
 import uniffi.wysiwyg_composer.newComposerModel
-import kotlin.math.absoluteValue
-import kotlin.math.min
 
 class EditorEditText : TextInputEditText {
 
@@ -62,17 +62,16 @@ class EditorEditText : TextInputEditText {
     var selectionChangeListener: OnSelectionChangeListener? = null
     var menuStateChangedListener: OnMenuStateChangedListener? = null
 
+    @Suppress("SAFE_CALL_WILL_CHANGE_NULLABILITY", "UNNECESSARY_SAFE_CALL")
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
         super.onSelectionChanged(selStart, selEnd)
-        if (inputProcessor != null) {
-            inputProcessor.updateSelection(editableText, selStart, selEnd)
-        }
+        inputProcessor?.updateSelection(editableText, selStart, selEnd)
         selectionChangeListener?.selectionChanged(selStart, selEnd)
     }
 
     /**
-     * We wrap the internal [EditableInputConnection] as it's not public, but its internal behavior
-     * is probably needed to work properly with the EditText.
+     * We wrap the internal `com.android.internal.widget.EditableInputConnection` as it's not
+     * public, but its internal behavior is needed to work properly with the EditText.
      */
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
         val baseInputConnection = requireNotNull(super.onCreateInputConnection(outAttrs))
@@ -87,7 +86,7 @@ class EditorEditText : TextInputEditText {
      */
     override fun onTextContextMenuItem(id: Int): Boolean {
         when (id) {
-            R.id.cut -> {
+            android.R.id.cut -> {
                 val clipboardManager = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                 val clpData = ClipData.newPlainText("newText", this.editableText.slice(this.selectionStart until this.selectionEnd))
                 clipboardManager.setPrimaryClip(clpData)
@@ -102,10 +101,10 @@ class EditorEditText : TextInputEditText {
 
                 return false
             }
-            R.id.paste, R.id.pasteAsPlainText -> {
+            android.R.id.paste, android.R.id.pasteAsPlainText -> {
                 val clipBoardManager = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                 val copiedString = clipBoardManager.primaryClip?.getItemAt(0)?.text ?: return false
-                val update = inputProcessor.processInput(EditorInputAction.InsertText(copiedString))
+                val update = inputProcessor.processInput(EditorInputAction.ReplaceText(copiedString))
                 val result = update?.let { inputProcessor.processUpdate(it) }
 
                 if (result != null) {
@@ -121,8 +120,8 @@ class EditorEditText : TextInputEditText {
 
     private fun addHardwareKeyInterceptor() {
         // This seems to be the only way to prevent EditText from automatically handling key strokes
-        setOnKeyListener { v, keyCode, event ->
-            if (event.keyCode == KeyEvent.KEYCODE_ENTER) {
+        setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_ENTER) {
                 if (event.action == MotionEvent.ACTION_DOWN) {
                     inputConnection?.sendHardwareKeyboardInput(event)
                 }
@@ -141,6 +140,7 @@ class EditorEditText : TextInputEditText {
         }
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     override fun setText(text: CharSequence?, type: BufferType?) {
         val currentText = this.text
         val end = currentText?.length ?: 0
@@ -150,7 +150,7 @@ class EditorEditText : TextInputEditText {
             super.setText(text, type)
         } else {
             inputProcessor.updateSelection(editableText, 0, end)
-            val update = inputProcessor.processInput(EditorInputAction.InsertText(text.toString()))
+            val update = inputProcessor.processInput(EditorInputAction.ReplaceText(text.toString()))
             val result = update?.let { inputProcessor.processUpdate(it) }
 
             if (result != null) {
@@ -170,7 +170,7 @@ class EditorEditText : TextInputEditText {
     }
 
     override fun append(text: CharSequence?, start: Int, end: Int) {
-        val update = inputProcessor.processInput(EditorInputAction.InsertText(text.toString()))
+        val update = inputProcessor.processInput(EditorInputAction.ReplaceText(text.toString()))
         val result = update?.let { inputProcessor.processUpdate(it) }
 
         if (result != null) {
@@ -247,13 +247,7 @@ class EditorEditText : TextInputEditText {
     }
 
     private fun setSelectionFromComposerUpdate(start: Int, end: Int = start) {
-        val zeroWidthLineBreaks = editableText.getSpans<HtmlToSpansParser.ZeroWidthLineBreak>()
-        val before = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= start }
-            .sumOf { (editableText.getSpanEnd(it) - editableText.getSpanStart(it)).absoluteValue }
-        val during = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= end }
-            .sumOf { (editableText.getSpanEnd(it) - editableText.getSpanStart(it)).absoluteValue }
-        val newStart = min(start + before, editableText.length)
-        val newEnd = min(end + during, editableText.length)
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditText(start, end, editableText)
         setSelection(newStart, newEnd)
     }
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/ComposerExtensions.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/ComposerExtensions.kt
@@ -8,9 +8,19 @@ import uniffi.wysiwyg_composer.ComposerState
 
 val LOG_ENABLED = BuildConfig.DEBUG
 
+/**
+ * Get the current HTML representation of the formatted text in the Rust code, along with its
+ * selection.
+ */
 fun ComposerState.dump() = "'${html.string()}' | Start: $start | End: $end"
-fun ComposerModelInterface.log() = if (LOG_ENABLED)
-    Log.d("COMPOSER_PROCESSOR", dumpState().dump()
+
+/**
+ * Log the current state of the editor in the Rust code.
+ */
+fun ComposerModelInterface.log() = if (LOG_ENABLED) {
+    Log.d(
+        "COMPOSER_PROCESSOR", dumpState().dump()
             // To visualize zero-width spaces easily
-        .replace("\u200b", "~"))
-else 0
+            .replace("\u200b", "~")
+    )
+} else 0

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/RustExtensions.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/RustExtensions.kt
@@ -1,5 +1,8 @@
 package io.element.android.wysiwyg.extensions
 
+/**
+ * Translates the Rust [UShort] list returned for strings into actual JVM Strings that we can use.
+ */
 fun List<UShort>.string() = with(StringBuffer()) {
     this@string.forEach {
         appendCodePoint(it.toInt())

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InputProcessor.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InputProcessor.kt
@@ -11,6 +11,7 @@ import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
 import io.element.android.wysiwyg.spans.ExtraCharacterSpan
+import io.element.android.wysiwyg.utils.EditorIndexMapper
 import io.element.android.wysiwyg.utils.HtmlToSpansParser
 import uniffi.wysiwyg_composer.ComposerModelInterface
 import uniffi.wysiwyg_composer.MenuState
@@ -24,12 +25,7 @@ internal class InputProcessor(
 ) {
 
     fun updateSelection(editable: Editable, start: Int, end: Int) {
-        if (start < 0 || end < 0) return
-        val zeroWidthLineBreaksBefore = editable.getSpans<ExtraCharacterSpan>(0, start)
-            .sumOf { (editable.getSpanEnd(it) - editable.getSpanStart(it)).absoluteValue }
-
-        val newStart = (start - zeroWidthLineBreaksBefore).toUInt()
-        val newEnd = (end - zeroWidthLineBreaksBefore).toUInt()
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editable) ?: return
 
         val update = composer?.select(newStart, newEnd)
         val menuState = update?.menuState()

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InputProcessor.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InputProcessor.kt
@@ -10,7 +10,7 @@ import io.element.android.wysiwyg.extensions.string
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
-import io.element.android.wysiwyg.spans.ZeroWidthLineBreak
+import io.element.android.wysiwyg.spans.ExtraCharacterSpan
 import io.element.android.wysiwyg.utils.HtmlToSpansParser
 import uniffi.wysiwyg_composer.ComposerModelInterface
 import uniffi.wysiwyg_composer.MenuState
@@ -25,7 +25,7 @@ internal class InputProcessor(
 
     fun updateSelection(editable: Editable, start: Int, end: Int) {
         if (start < 0 || end < 0) return
-        val zeroWidthLineBreaksBefore = editable.getSpans<ZeroWidthLineBreak>(0, start)
+        val zeroWidthLineBreaksBefore = editable.getSpans<ExtraCharacterSpan>(0, start)
             .sumOf { (editable.getSpanEnd(it) - editable.getSpanStart(it)).absoluteValue }
 
         val newStart = (start - zeroWidthLineBreaksBefore).toUInt()

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -288,8 +288,8 @@ internal class InterceptInputConnection(
     }
 
     private fun setSelectionOnEditable(editable: Editable, start: Int, end: Int = start) {
-        val newStart = min(EditorIndexMapper.composerIndexForEditable(start, editable), editable.length)
-        val newEnd = min(EditorIndexMapper.composerIndexForEditable(end, editable), editable.length)
+        val newStart = min(EditorIndexMapper.editorIndexFromComposer(start, editable), editable.length)
+        val newEnd = min(EditorIndexMapper.editorIndexFromComposer(end, editable), editable.length)
         Selection.setSelection(editable, newStart, newEnd)
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -1,4 +1,4 @@
-package io.element.android.wysiwyg
+package io.element.android.wysiwyg.inputhandlers
 
 import android.os.Build
 import android.os.Bundle
@@ -11,8 +11,8 @@ import android.view.inputmethod.*
 import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
-import androidx.core.text.getSpans
-import io.element.android.wysiwyg.spans.HtmlToSpansParser
+import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
+import io.element.android.wysiwyg.utils.EditorIndexMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.min
 
-class InterceptInputConnection(
+internal class InterceptInputConnection(
     private val baseInputConnection: InputConnection,
     private val editorEditText: TextView,
     private val inputProcessor: InputProcessor,
@@ -35,7 +35,7 @@ class InterceptInputConnection(
     init {
         keyEventJob = processKeyEvents()
         // TODO: remove this once we have an initial menu state update
-        inputProcessor.processInput(EditorInputAction.InsertText(""))
+        inputProcessor.processInput(EditorInputAction.ReplaceText(""))
     }
 
     override fun getEditable(): Editable {
@@ -125,7 +125,7 @@ class InterceptInputConnection(
         val (start, end) = getCurrentCompositionOrSelection()
         inputProcessor.updateSelection(editable, start, end)
         val result = withProcessor {
-            processInput(EditorInputAction.InsertText(text.toString()))?.let { processUpdate(it) }
+            processInput(EditorInputAction.ReplaceText(text.toString()))?.let { processUpdate(it) }
         }
 
         return if (result != null) {
@@ -135,7 +135,7 @@ class InterceptInputConnection(
             if (text is Spannable && result.text is Spannable) {
                 copyImeHighlightSpans(text, result.text, start)
             }
-            replaceAll(result.text, compositionStart = start, compositionEnd = compositionEnd, newCursorPosition)
+            replaceAll(result.text, compositionStart = start, compositionEnd = compositionEnd)
             setSelectionOnEditable(editable, result.selection.last, result.selection.last)
             true
         } else {
@@ -151,12 +151,12 @@ class InterceptInputConnection(
                 processInput(EditorInputAction.InsertParagraph)
             } else {
                 inputProcessor.updateSelection(editable, start, end)
-                processInput(EditorInputAction.InsertText(text.toString()))
+                processInput(EditorInputAction.ReplaceText(text.toString()))
             }?.let { processUpdate(it) }
         }
 
         return if (result != null) {
-            replaceAll(result.text, compositionStart = end, compositionEnd = end, newCursorPosition)
+            replaceAll(result.text, compositionStart = end, compositionEnd = end)
             setSelectionOnEditable(editable, result.selection.last, result.selection.last)
             true
         } else {
@@ -217,7 +217,7 @@ class InterceptInputConnection(
                 processInput(EditorInputAction.BackPress)?.let { processUpdate(it) }
             }
             if (result != null) {
-                replaceAll(result.text, 0, editable.length, 1)
+                replaceAll(result.text, 0, editable.length)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
                 setComposingRegion(result.selection.first, result.selection.last)
             }
@@ -231,7 +231,7 @@ class InterceptInputConnection(
                 processInput(EditorInputAction.BackPress)?.let { processUpdate(it) }
             }
             if (result != null) {
-                replaceAll(result.text, 0, editable.length, 1)
+                replaceAll(result.text, 0, editable.length)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
                 setComposingRegion(result.selection.first, result.selection.last)
             }
@@ -265,7 +265,11 @@ class InterceptInputConnection(
         return start to end
     }
 
-    private fun replaceAll(charSequence: CharSequence, compositionStart: Int, compositionEnd: Int, newCursorPosition: Int) {
+    private fun replaceAll(
+        charSequence: CharSequence,
+        compositionStart: Int,
+        compositionEnd: Int,
+    ) {
         beginBatchEdit()
         editable.clear()
         editable.replace(0, editable.length, charSequence)
@@ -284,25 +288,9 @@ class InterceptInputConnection(
     }
 
     private fun setSelectionOnEditable(editable: Editable, start: Int, end: Int = start) {
-        val newStart = min(composerIndexInEditable(start), editable.length)
-        val newEnd = min(composerIndexInEditable(end), editable.length)
+        val newStart = min(EditorIndexMapper.composerIndexForEditable(start, editable), editable.length)
+        val newEnd = min(EditorIndexMapper.composerIndexForEditable(end, editable), editable.length)
         Selection.setSelection(editable, newStart, newEnd)
-    }
-
-    private fun composerIndexInEditable(index: Int): Int {
-        val editable = this.editable
-        var consumed = 0
-        var i = 0
-        while (index > consumed) {
-            val spans = editable.getSpans<HtmlToSpansParser.ZeroWidthLineBreak>(start = i, end = i+1)
-            if (spans.isEmpty()) {
-                consumed++
-                i++
-            } else {
-                i += spans.count()
-            }
-        }
-        return i
     }
 
     private fun <T> withProcessor(block: InputProcessor.() -> T): T {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
@@ -1,0 +1,59 @@
+package io.element.android.wysiwyg.inputhandlers.models
+
+import uniffi.wysiwyg_composer.ComposerModel
+
+/**
+ * Text editing actions to be performed by the Rust code through the [ComposerModel] component.
+ */
+sealed interface EditorInputAction {
+    /**
+     * Replaces the text at the current selection with the provided [value] in plain text.
+     */
+    data class ReplaceText(val value: CharSequence): EditorInputAction
+
+    /**
+     * Replaces the whole contents of the editor with the passed [html], re-creating the Dom.
+     */
+    data class ReplaceAllHtml(val html: String): EditorInputAction
+
+    /**
+     * Deletes text in the [start]..[end] selection
+     */
+    data class Delete(val start: Int, val end: Int): EditorInputAction
+
+    /**
+     * Adds a new line break at the current selection.
+     */
+    object InsertParagraph: EditorInputAction
+
+    /**
+     * Removes text in a backwards direction given the current selection.
+     */
+    object BackPress: EditorInputAction
+
+    /**
+     * Applies the passed inline [format] to the current selection, either creating or extending it
+     * or removing it if it was present in that selection.
+     */
+    data class ApplyInlineFormat(val format: InlineFormat): EditorInputAction
+
+    /**
+     * Un-does the previous action, restoring the previous editor state.
+     */
+    object Undo: EditorInputAction
+
+    /**
+     * Re-does the last undone action, restoring its state.
+     */
+    object Redo: EditorInputAction
+
+    /**
+     * Creates a link to the [link] url in the current selection.
+     */
+    data class SetLink(val link: String): EditorInputAction
+
+    /**
+     * Creates a list, [ordered] if true or unordered in the current selection.
+     */
+    data class ToggleList(val ordered: Boolean): EditorInputAction
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/InlineFormat.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/InlineFormat.kt
@@ -1,0 +1,15 @@
+package io.element.android.wysiwyg.inputhandlers.models
+
+import uniffi.wysiwyg_composer.ComposerAction
+
+/**
+ * Mapping of [ComposerAction] inline format actions. These are text styles that can be applied to
+ * a text selection in the editor.
+ */
+sealed interface InlineFormat {
+    object Bold: InlineFormat
+    object Italic: InlineFormat
+    object Underline: InlineFormat
+    object StrikeThrough: InlineFormat
+    object InlineCode: InlineFormat
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/ReplaceTextResult.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/ReplaceTextResult.kt
@@ -1,0 +1,15 @@
+package io.element.android.wysiwyg.inputhandlers.models
+
+import android.text.Spanned
+import android.widget.EditText
+import uniffi.wysiwyg_composer.TextUpdate.ReplaceAll
+
+/**
+ * Mapped model of [ReplaceAll] from the Rust code to be applied to the [EditText].
+ */
+internal data class ReplaceTextResult(
+    /** Text in [Spanned] format after being parsed from HTML. */
+    val text: CharSequence,
+    /** Selection to apply to the editor. */
+    val selection: IntRange,
+)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/ExtraCharacterSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/ExtraCharacterSpan.kt
@@ -9,8 +9,8 @@ import uniffi.wysiwyg_composer.ComposerModel
  *
  * This is done because in the Dom, just using a `<li>` tag will create a new line break in a list,
  * but for Android we have to add an extra `\n` line break character for list items to be rendered
- * properly. To fix this mismatch, we use this [ZeroWidthLineBreak] to understand when a line break
+ * properly. To fix this mismatch, we use this [ExtraCharacterSpan] to understand when a line break
  * character should be left as is, because it exists in the [ComposerModel] or if we should handle
  * it in a special way because it's not present in the HTML output.
  */
-class ZeroWidthLineBreak: NoCopySpan
+class ExtraCharacterSpan: NoCopySpan

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
@@ -10,6 +10,10 @@ import android.text.style.TypefaceSpan
 import android.text.style.UpdateAppearance
 import androidx.core.content.ContextCompat
 
+/**
+ * Inline code (`some code` in Markdown, <code> in HTML) Span that applies a monospaced font style
+ * and adds a background color.
+ */
 class InlineCodeSpan : MetricAffectingSpan, UpdateAppearance, ParcelableSpan {
 
     private val monoTypefaceSpan: TypefaceSpan

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/OrderedListSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/OrderedListSpan.kt
@@ -7,6 +7,10 @@ import android.graphics.Typeface
 import android.text.Layout
 import android.text.style.LeadingMarginSpan
 
+/**
+ * Custom ordered list span (<ol> in HTML), prints a prefix with the current list item number and
+ * applies a margin to the item.
+ */
 class OrderedListSpan(
     typeface: Typeface,
     textSize: Float,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/ZeroWidthLineBreak.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/ZeroWidthLineBreak.kt
@@ -1,0 +1,16 @@
+package io.element.android.wysiwyg.spans
+
+import android.text.NoCopySpan
+import uniffi.wysiwyg_composer.ComposerModel
+
+/**
+ * Special 'span' used as a marker to know there's a difference between the indexes in the Rust code
+ * and the ones in the UI components.
+ *
+ * This is done because in the Dom, just using a `<li>` tag will create a new line break in a list,
+ * but for Android we have to add an extra `\n` line break character for list items to be rendered
+ * properly. To fix this mismatch, we use this [ZeroWidthLineBreak] to understand when a line break
+ * character should be left as is, because it exists in the [ComposerModel] or if we should handle
+ * it in a special way because it's not present in the HTML output.
+ */
+class ZeroWidthLineBreak: NoCopySpan

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/EditorIndexMapper.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/EditorIndexMapper.kt
@@ -3,14 +3,14 @@ package io.element.android.wysiwyg.utils
 import android.text.Editable
 import android.text.Spanned
 import androidx.core.text.getSpans
-import io.element.android.wysiwyg.spans.ZeroWidthLineBreak
+import io.element.android.wysiwyg.spans.ExtraCharacterSpan
 import kotlin.math.absoluteValue
 import kotlin.math.min
 import uniffi.wysiwyg_composer.ComposerModel
 
 /**
  * The indexes in the [Editable] text and [ComposerModel] may differ if we take into account
- * [ZeroWidthLineBreak] that are added for lists.
+ * [ExtraCharacterSpan] that are added for lists.
  *
  * These spans are used to mark extra characters that are not present in the original HTML output,
  * mainly extra line breaks between list items.
@@ -21,19 +21,19 @@ object EditorIndexMapper {
      * Translates the [start], [end] indexes that come from the [ComposerModel] into indexes that
      * can be safely used in the [editableText].
      *
-     * For this, [ZeroWidthLineBreak] spans are used: we look for them in the [editableText], then
+     * For this, [ExtraCharacterSpan] spans are used: we look for them in the [editableText], then
      * sum their lengths and add this extra length to the [start] and [end] original indexes.
      */
-    fun fromComposerToEditText(start: Int, end: Int, editableText: Editable): Pair<Int, Int> {
+    fun fromComposerToEditor(start: Int, end: Int, editableText: Spanned): Pair<Int, Int> {
         // Invalid indexes
         if (start < 0 || end < 0) return -1 to -1
 
-        val zeroWidthLineBreaks = editableText.getSpans<ZeroWidthLineBreak>()
+        val extraCharacters = editableText.getSpans<ExtraCharacterSpan>()
         // Extra offset to add to the start index
-        val before = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= start }
+        val before = extraCharacters.filter { editableText.getSpanStart(it) <= start }
             .sumOf { editableText.getSpanLength(it) }
         // Extra offset to add to the end index
-        val during = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= end }
+        val during = extraCharacters.filter { editableText.getSpanStart(it) <= end }
             .sumOf { editableText.getSpanLength(it) }
         val newStart = min(start + before, editableText.length)
         val newEnd = min(end + during, editableText.length)
@@ -44,18 +44,18 @@ object EditorIndexMapper {
      * Translates the [start], [end] indexes that come from the [editableText] into indexes that
      * can be safely used in the [ComposerModel].
      *
-     * For this, [ZeroWidthLineBreak] spans are used: we look for them in the [editableText], then
+     * For this, [ExtraCharacterSpan] spans are used: we look for them in the [editableText], then
      * sum their lengths and subtract these lengths to the [start] and [end] original indexes.
      */
-    fun fromEditorToComposer(start: Int, end: Int, editableText: Editable): Pair<UInt, UInt>? {
+    fun fromEditorToComposer(start: Int, end: Int, editableText: Spanned): Pair<UInt, UInt>? {
         // Invalid indexes
         if (start < 0 || end < 0) return null
 
-        val zeroWidthLineBreaksBefore = editableText.getSpans<ZeroWidthLineBreak>(0, start)
+        val extraCharactersBeforeStart = editableText.getSpans<ExtraCharacterSpan>(0, start)
             .sumOf { editableText.getSpanLength(it) }
 
-        val newStart = (start - zeroWidthLineBreaksBefore).toUInt()
-        val newEnd = (end - zeroWidthLineBreaksBefore).toUInt()
+        val newStart = (start - extraCharactersBeforeStart).toUInt()
+        val newEnd = (end - extraCharactersBeforeStart).toUInt()
 
         return newStart to newEnd
     }
@@ -64,11 +64,11 @@ object EditorIndexMapper {
      * Translates the [index] coming from the [editableText] into one that can be safely used
      * in the [ComposerModel].
      */
-    fun composerIndexForEditable(index: Int, editableText: Editable): Int {
+    fun composerIndexForEditable(index: Int, editableText: Spanned): Int {
         var consumed = 0
         var i = 0
         while (index > consumed) {
-            val spans = editableText.getSpans<ZeroWidthLineBreak>(start = i, end = i+1)
+            val spans = editableText.getSpans<ExtraCharacterSpan>(start = i, end = i+1)
             if (spans.isEmpty()) {
                 consumed++
                 i++

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/EditorIndexMapper.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/EditorIndexMapper.kt
@@ -1,0 +1,86 @@
+package io.element.android.wysiwyg.utils
+
+import android.text.Editable
+import android.text.Spanned
+import androidx.core.text.getSpans
+import io.element.android.wysiwyg.spans.ZeroWidthLineBreak
+import kotlin.math.absoluteValue
+import kotlin.math.min
+import uniffi.wysiwyg_composer.ComposerModel
+
+/**
+ * The indexes in the [Editable] text and [ComposerModel] may differ if we take into account
+ * [ZeroWidthLineBreak] that are added for lists.
+ *
+ * These spans are used to mark extra characters that are not present in the original HTML output,
+ * mainly extra line breaks between list items.
+ */
+object EditorIndexMapper {
+
+    /**
+     * Translates the [start], [end] indexes that come from the [ComposerModel] into indexes that
+     * can be safely used in the [editableText].
+     *
+     * For this, [ZeroWidthLineBreak] spans are used: we look for them in the [editableText], then
+     * sum their lengths and add this extra length to the [start] and [end] original indexes.
+     */
+    fun fromComposerToEditText(start: Int, end: Int, editableText: Editable): Pair<Int, Int> {
+        // Invalid indexes
+        if (start < 0 || end < 0) return -1 to -1
+
+        val zeroWidthLineBreaks = editableText.getSpans<ZeroWidthLineBreak>()
+        // Extra offset to add to the start index
+        val before = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= start }
+            .sumOf { editableText.getSpanLength(it) }
+        // Extra offset to add to the end index
+        val during = zeroWidthLineBreaks.filter { editableText.getSpanStart(it) <= end }
+            .sumOf { editableText.getSpanLength(it) }
+        val newStart = min(start + before, editableText.length)
+        val newEnd = min(end + during, editableText.length)
+        return newStart to newEnd
+    }
+
+    /**
+     * Translates the [start], [end] indexes that come from the [editableText] into indexes that
+     * can be safely used in the [ComposerModel].
+     *
+     * For this, [ZeroWidthLineBreak] spans are used: we look for them in the [editableText], then
+     * sum their lengths and subtract these lengths to the [start] and [end] original indexes.
+     */
+    fun fromEditorToComposer(start: Int, end: Int, editableText: Editable): Pair<UInt, UInt>? {
+        // Invalid indexes
+        if (start < 0 || end < 0) return null
+
+        val zeroWidthLineBreaksBefore = editableText.getSpans<ZeroWidthLineBreak>(0, start)
+            .sumOf { editableText.getSpanLength(it) }
+
+        val newStart = (start - zeroWidthLineBreaksBefore).toUInt()
+        val newEnd = (end - zeroWidthLineBreaksBefore).toUInt()
+
+        return newStart to newEnd
+    }
+
+    /**
+     * Translates the [index] coming from the [editableText] into one that can be safely used
+     * in the [ComposerModel].
+     */
+    fun composerIndexForEditable(index: Int, editableText: Editable): Int {
+        var consumed = 0
+        var i = 0
+        while (index > consumed) {
+            val spans = editableText.getSpans<ZeroWidthLineBreak>(start = i, end = i+1)
+            if (spans.isEmpty()) {
+                consumed++
+                i++
+            } else {
+                i += spans.count()
+            }
+        }
+        return i
+    }
+
+}
+
+private fun Spanned.getSpanLength(span: Any): Int {
+    return (getSpanEnd(span) - getSpanStart(span)).absoluteValue
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -1,8 +1,7 @@
-package io.element.android.wysiwyg.spans
+package io.element.android.wysiwyg.utils
 
 import android.content.Context
 import android.graphics.Typeface
-import android.text.NoCopySpan
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -11,7 +10,10 @@ import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
 import androidx.core.text.getSpans
-import io.element.android.wysiwyg.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
+import io.element.android.wysiwyg.spans.InlineCodeSpan
+import io.element.android.wysiwyg.spans.OrderedListSpan
+import io.element.android.wysiwyg.spans.ZeroWidthLineBreak
 import org.ccil.cowan.tagsoup.Parser
 import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
@@ -20,6 +22,13 @@ import org.xml.sax.Locator
 import java.io.StringReader
 import kotlin.math.roundToInt
 
+/**
+ * Custom HTML to Span parser so we can customise what each HTML tag will be represented with in the
+ * formatted text.
+ *
+ * This is specially important for lists, since they not only use custom spans, but they also need
+ * to create [ZeroWidthLineBreak] spans to work properly.
+ */
 class HtmlToSpansParser(
     private val context: Context,
     private val html: String,
@@ -28,7 +37,6 @@ class HtmlToSpansParser(
     data class Hyperlink(val link: String)
     object OrderedListBlock
     object UnorderedListBlock
-    class ZeroWidthLineBreak: NoCopySpan
     data class ListItem(val ordered: Boolean, val order: Int? = null)
 
     private val parser = Parser().also { it.contentHandler = this }
@@ -82,7 +90,7 @@ class HtmlToSpansParser(
                 handleHyperlinkStart(url)
             }
             "ul", "ol" -> {
-                val mark = if (name == "ol") OrderedListBlock else UnorderedListBlock
+                val mark: Any = if (name == "ol") OrderedListBlock else UnorderedListBlock
                 text.setSpan(mark, text.length, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
             }
             "li" -> {
@@ -112,7 +120,7 @@ class HtmlToSpansParser(
             "code" -> handleFormatEndTag(InlineFormat.InlineCode)
             "a" -> handleHyperlinkEnd()
             "ul", "ol" -> {
-                val mark = if (name == "ol") OrderedListBlock else UnorderedListBlock
+                val mark: Any = if (name == "ol") OrderedListBlock else UnorderedListBlock
                 val last = getLast(mark::class.java) ?: return
                 text.removeSpan(last)
             }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -130,16 +130,16 @@ class HtmlToSpansParser(
                 var lineBreakAdded = false
                 // We only add line breaks *after* a previous <li> element if there is not already a line break
                 if (start == 0) {
-                    val zeroWidthSpan = SpannableString("\u200b").apply {
+                    val extraZeroWidthSpan = SpannableString("\u200b").apply {
                         setSpan(ExtraCharacterSpan(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
-                    text.insert(0, zeroWidthSpan)
+                    text.insert(0, extraZeroWidthSpan)
                 } else if (start > 0 && start <= text.length && text[start-1] != '\n') {
                     // We add a line break and an zero width character to actually display the list item
-                    val zeroWidthLineBreakSpan = SpannableString("\n").apply {
+                    val extraLineBreakSpan = SpannableString("\n").apply {
                         setSpan(ExtraCharacterSpan(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
-                    text.insert(start, zeroWidthLineBreakSpan)
+                    text.insert(start, extraLineBreakSpan)
                     lineBreakAdded = true
                 }
                 val newStart = if (lineBreakAdded) start+1 else start

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -13,7 +13,7 @@ import androidx.core.text.getSpans
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.spans.InlineCodeSpan
 import io.element.android.wysiwyg.spans.OrderedListSpan
-import io.element.android.wysiwyg.spans.ZeroWidthLineBreak
+import io.element.android.wysiwyg.spans.ExtraCharacterSpan
 import org.ccil.cowan.tagsoup.Parser
 import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
@@ -27,7 +27,7 @@ import kotlin.math.roundToInt
  * formatted text.
  *
  * This is specially important for lists, since they not only use custom spans, but they also need
- * to create [ZeroWidthLineBreak] spans to work properly.
+ * to create [ExtraCharacterSpan] spans to work properly.
  */
 class HtmlToSpansParser(
     private val context: Context,
@@ -131,13 +131,13 @@ class HtmlToSpansParser(
                 // We only add line breaks *after* a previous <li> element if there is not already a line break
                 if (start == 0) {
                     val zeroWidthSpan = SpannableString("\u200b").apply {
-                        setSpan(ZeroWidthLineBreak(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        setSpan(ExtraCharacterSpan(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
                     text.insert(0, zeroWidthSpan)
                 } else if (start > 0 && start <= text.length && text[start-1] != '\n') {
                     // We add a line break and an zero width character to actually display the list item
                     val zeroWidthLineBreakSpan = SpannableString("\n").apply {
-                        setSpan(ZeroWidthLineBreak(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        setSpan(ExtraCharacterSpan(), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
                     text.insert(start, zeroWidthLineBreakSpan)
                     lineBreakAdded = true

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
@@ -13,20 +13,20 @@ import org.robolectric.RobolectricTestRunner
 class EditorIndexMapperTests {
 
     private val editableText = buildSpannedString {
-        append("Plain text.\n")
+        append("Plain text.\n") // 12 characters
         inSpans(BulletSpan()) {
-            append("First item.")
+            append("First item.") // 11 characters, ends at index 23
         }
         inSpans(ExtraCharacterSpan()) {
-            append("\n")
+            append("\n") // 1 extra character, ends at index 24
         }
         inSpans(BulletSpan()) {
-            append("Second item.")
+            append("Second item.") // 12 characters, ends at index 36
         }
         inSpans(ExtraCharacterSpan()) {
-            append("\n")
+            append("\n") // 1 extra character, ends at index 37
         }
-        append("After list.")
+        append("After list.") // 11 characters, ends at index 48
     }
 
     //region Index before extra characters
@@ -139,6 +139,26 @@ class EditorIndexMapperTests {
         val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editableText)!!
         Assert.assertEquals(start-1, newStart.toInt())
         Assert.assertEquals(end-2, newEnd.toInt())
+    }
+    // endregion
+
+    // region Selection covers only the extra character
+    @Test
+    fun `given a selection covering only the extra character, when using fromComposerToEditor, then the indexes have an offset, but start and end won't match`() {
+        val start = 23
+        val end = 24
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
+        Assert.assertEquals(start, newStart)
+        Assert.assertEquals(end+1, newEnd)
+    }
+
+    @Test
+    fun `given a selection covering only the extra character, when using fromEditorToComposer, then the indexes have an offset, but start and end won't match`() {
+        val start = 23
+        val end = 24
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editableText)!!
+        Assert.assertEquals(start, newStart.toInt())
+        Assert.assertEquals(end-1, newEnd.toInt())
     }
     // endregion
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
@@ -1,0 +1,144 @@
+package io.element.android.wysiwyg.utils
+
+import android.text.style.BulletSpan
+import androidx.core.text.buildSpannedString
+import androidx.core.text.inSpans
+import io.element.android.wysiwyg.spans.ExtraCharacterSpan
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EditorIndexMapperTests {
+
+    private val editableText = buildSpannedString {
+        append("Plain text.\n")
+        inSpans(BulletSpan()) {
+            append("First item.")
+        }
+        inSpans(ExtraCharacterSpan()) {
+            append("\n")
+        }
+        inSpans(BulletSpan()) {
+            append("Second item.")
+        }
+        inSpans(ExtraCharacterSpan()) {
+            append("\n")
+        }
+        append("After list.")
+    }
+
+    //region Index before extra characters
+    @Test
+    fun `given an index with no extra characters before it, when using fromComposerToEditor, then the indexes match`() {
+        val index = 0
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(index, index, editableText)
+        Assert.assertEquals(index, newStart)
+        Assert.assertEquals(index, newEnd)
+    }
+
+    @Test
+    fun `given an index with no extra characters before it, when using fromEditorToComposer, then the indexes match`() {
+        val index = 0
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
+        Assert.assertEquals(index.toUInt(), newStart)
+        Assert.assertEquals(index.toUInt(), newEnd)
+    }
+    //endregion
+
+    //region Invalid indexes passed
+    @Test
+    fun `given an invalid index, when using fromComposerToEditor, then the result indexes are -1`() {
+        val index = -1
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(index, index, editableText)
+        Assert.assertEquals(-1, newStart)
+        Assert.assertEquals(-1, newEnd)
+    }
+
+    @Test
+    fun `given an invalid index, when using fromEditorToComposer, then it returns null`() {
+        val index = -1
+        val result = EditorIndexMapper.fromEditorToComposer(index, index, editableText)
+        Assert.assertNull(result)
+    }
+    //endregion
+
+    // region Index after an extra character
+    @Test
+    fun `given an index with an extra character before it, when using fromComposerToEditor, then the indexes have an offset`() {
+        val index = 25
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(index, index, editableText)
+        Assert.assertEquals(index+1, newStart)
+        Assert.assertEquals(index+1, newEnd)
+    }
+
+    @Test
+    fun `given an index with an extra character before it, when using fromEditorToComposer, then the indexes have an offset`() {
+        val index = 25
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
+        Assert.assertEquals(index-1, newStart.toInt())
+        Assert.assertEquals(index-1, newEnd.toInt())
+    }
+    // endregion
+
+    // region Selection is after an extra character
+    @Test
+    fun `given a selection with an extra character before it, when using fromComposerToEditor, then the indexes have an offset`() {
+        val start = 25
+        val end = 28
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
+        Assert.assertEquals(start+1, newStart)
+        Assert.assertEquals(end+1, newEnd)
+    }
+
+    @Test
+    fun `given a selection with an extra character before it, when using fromEditorToComposer, then the indexes have an offset`() {
+        val start = 25
+        val end = 28
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editableText)!!
+        Assert.assertEquals(start-1, newStart.toInt())
+        Assert.assertEquals(end-1, newEnd.toInt())
+    }
+    // endregion
+
+    // region Selection covers an extra character
+    @Test
+    fun `given a selection with an extra character in the middle of it, when using fromComposerToEditor, then the end index have an offset`() {
+        val start = 22
+        val end = 25
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
+        Assert.assertEquals(start, newStart)
+        Assert.assertEquals(end+1, newEnd)
+    }
+
+    @Test
+    fun `given a selection with an extra character in the middle of it, when using fromEditorToComposer, then the end index have an offset`() {
+        val start = 22
+        val end = 25
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editableText)!!
+        Assert.assertEquals(start, newStart.toInt())
+        Assert.assertEquals(end-1, newEnd.toInt())
+    }
+    // endregion
+
+    // region Selection covers an extra character after a previous one
+    @Test
+    fun `given a selection covering an extra character with another one before it, when using fromComposerToEditor, then the indexes have an offset, but start and end won't match`() {
+        val start = 28
+        val end = 40
+        val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
+        Assert.assertEquals(start+1, newStart)
+        Assert.assertEquals(end+2, newEnd)
+    }
+
+    @Test
+    fun `given a selection covering an extra character with another one before it, when using fromEditorToComposer, then the indexes have an offset, but start and end won't match`() {
+        val start = 28
+        val end = 40
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editableText)!!
+        Assert.assertEquals(start-1, newStart.toInt())
+        Assert.assertEquals(end-2, newEnd.toInt())
+    }
+    // endregion
+}


### PR DESCRIPTION
Important changes:

* Index mapping was moved to the `EditorIndexMapper` object.
* Most classes were moved to packages to arrange the code better. Only `EditorEditText` remains at the root package to avoid breaking the current use in any clients.
* `EditorInputAction.InsertText` was renamed to `ReplaceText`, as that's what it actually does.
* `ZeroWitdhLineBreak` span is now `ExtraCharacterSpan` to reflect why it's added to the `Spannable` strings.
* Added docs to most classes.
* Fixed some lint issues.

It's probably better to rebase and merge it after #220 .