### PR TITLE
feat(wasm): Reduce the Wasm module size by 76%

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,23 @@
+name: Wasm
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install `wasm-pack`
+      run: cargo install wasm-pack
+    - name: Test the `wysiwyg` crate
+      working-directory: crates/wysiwyg
+      run: wasm-pack test --release --firefox --headless -- --no-default-features --features js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,10 +1140,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
-name = "web-sys"
-version = "0.3.58"
+name = "wasm-bindgen-test"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1242,6 +1272,8 @@ dependencies = [
  "once_cell",
  "speculoos",
  "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
  "widestring",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 name = "wysiwyg"
 version = "0.3.2"
 dependencies = [
+ "cfg-if",
  "html-escape",
  "html5ever",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1069,9 +1069,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1079,13 +1079,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
@@ -1241,6 +1241,7 @@ dependencies = [
  "html5ever",
  "once_cell",
  "speculoos",
+ "wasm-bindgen",
  "widestring",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bindings/wysiwyg-wasm",
     "crates/wysiwyg",
 ]
+resolver = "2"
 
 [profile.release]
 opt-level = 'z'     # Optimize for size.

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -26,8 +26,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-js-sys = "0.3.49"
-wasm-bindgen = "0.2.80"
-wasm-bindgen-futures = "0.4.30"
+js-sys = "0.3.60"
+wasm-bindgen = "0.2.83"
+wasm-bindgen-futures = "0.4.33"
 widestring = "1.0.2"
 wysiwyg = { path = "../../crates/wysiwyg" }

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -30,4 +30,4 @@ js-sys = "0.3.60"
 wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "0.4.33"
 widestring = "1.0.2"
-wysiwyg = { path = "../../crates/wysiwyg" }
+wysiwyg = { path = "../../crates/wysiwyg", default-features = false, features = ["js"] }

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -11,12 +11,16 @@ version = "0.3.2"
 rust-version = "1.60"
 
 [features]
+default = ["sys"]
+sys = ["dep:html5ever"]
+js = ["dep:wasm-bindgen"]
 
 [dependencies]
 html-escape = "0.2.11"
-html5ever = "0.25.2"
+html5ever = { version = "0.25.2", optional = true }
 once_cell = "1.13.0"
 widestring = "1.0.2"
+wasm-bindgen = { version = "0.2.83", optional = true }
 
 [dev-dependencies]
 speculoos = "0.9"

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -13,14 +13,18 @@ rust-version = "1.60"
 [features]
 default = ["sys"]
 sys = ["dep:html5ever"]
-js = ["dep:wasm-bindgen"]
+js = ["dep:wasm-bindgen", "dep:web-sys"]
 
 [dependencies]
 html-escape = "0.2.11"
 html5ever = { version = "0.25.2", optional = true }
 once_cell = "1.13.0"
 widestring = "1.0.2"
-wasm-bindgen = { version = "0.2.83", optional = true }
+wasm-bindgen = { version = "0.2.83", default-features = false, optional = true }
+web-sys = { version = "0.3.60", default-features = false, features = ["Document", "DomParser", "HtmlElement", "Node", "NodeList", "SupportedType"], optional = true }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 speculoos = "0.9"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.33"

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = "1.13.0"
 widestring = "1.0.2"
 wasm-bindgen = { version = "0.2.83", default-features = false, optional = true }
 web-sys = { version = "0.3.60", default-features = false, features = ["Document", "DomParser", "HtmlElement", "Node", "NodeList", "SupportedType"], optional = true }
+cfg-if = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 speculoos = "0.9"

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -407,7 +407,7 @@ impl SelectionWritingState {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use speculoos::{prelude::*, AssertionFailure, Spec};
     use widestring::Utf16String;

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -72,6 +72,15 @@ where
         self.document().children()
     }
 
+    #[cfg(feature = "js")]
+    pub(crate) fn take_children(self) -> Vec<DomNode<S>> {
+        if let DomNode::Container(container) = self.document {
+            container.take_children()
+        } else {
+            panic!("Document should always be a Container!")
+        }
+    }
+
     pub fn append_child(&mut self, child: DomNode<S>) -> DomHandle {
         self.document_mut().append_child(child)
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -211,6 +211,11 @@ where
         &self.children
     }
 
+    #[cfg(feature = "js")]
+    pub(crate) fn take_children(self) -> Vec<DomNode<S>> {
+        self.children
+    }
+
     pub fn kind(&self) -> &ContainerNodeKind<S> {
         &self.kind
     }

--- a/crates/wysiwyg/src/dom/parser.rs
+++ b/crates/wysiwyg/src/dom/parser.rs
@@ -37,21 +37,22 @@ mod panode_text;
 mod paqual_name;
 mod parse;
 
+// Group all re-exports for `feature = "sys"`.
 #[cfg(feature = "sys")]
-use padom::PaDom;
+mod sys {
+    use super::*;
+
+    pub(super) use padom::PaDom;
+    pub(super) use padom_creation_error::PaDomCreationError;
+    pub(super) use padom_creator::PaDomCreator;
+    pub(super) use padom_handle::PaDomHandle;
+    pub(super) use padom_node::PaDomNode;
+    pub(super) use panode_container::PaNodeContainer;
+    pub(super) use panode_text::PaNodeText;
+    pub(super) use paqual_name::paqual_name;
+}
+
 #[cfg(feature = "sys")]
-use padom_creation_error::PaDomCreationError;
-#[cfg(feature = "sys")]
-use padom_creator::PaDomCreator;
-#[cfg(feature = "sys")]
-use padom_handle::PaDomHandle;
-#[cfg(feature = "sys")]
-use padom_node::PaDomNode;
-#[cfg(feature = "sys")]
-use panode_container::PaNodeContainer;
-#[cfg(feature = "sys")]
-use panode_text::PaNodeText;
-#[cfg(feature = "sys")]
-use paqual_name::paqual_name;
+use sys::*;
 
 pub use parse::parse;

--- a/crates/wysiwyg/src/dom/parser.rs
+++ b/crates/wysiwyg/src/dom/parser.rs
@@ -19,22 +19,39 @@
 //! [super::Dom]. All instances of classes within this module are thrown away
 //! when parsing finishes.
 
+#[cfg(feature = "sys")]
 mod padom;
+#[cfg(feature = "sys")]
 mod padom_creation_error;
+#[cfg(feature = "sys")]
 mod padom_creator;
+#[cfg(feature = "sys")]
 mod padom_handle;
+#[cfg(feature = "sys")]
 mod padom_node;
+#[cfg(feature = "sys")]
 mod panode_container;
+#[cfg(feature = "sys")]
 mod panode_text;
+#[cfg(feature = "sys")]
 mod paqual_name;
 mod parse;
 
+#[cfg(feature = "sys")]
 use padom::PaDom;
+#[cfg(feature = "sys")]
 use padom_creation_error::PaDomCreationError;
+#[cfg(feature = "sys")]
 use padom_creator::PaDomCreator;
+#[cfg(feature = "sys")]
 use padom_handle::PaDomHandle;
+#[cfg(feature = "sys")]
 use padom_node::PaDomNode;
+#[cfg(feature = "sys")]
 use panode_container::PaNodeContainer;
+#[cfg(feature = "sys")]
 use panode_text::PaNodeText;
+#[cfg(feature = "sys")]
 use paqual_name::paqual_name;
+
 pub use parse::parse;

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -12,256 +12,301 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::dom::nodes::{ContainerNode, DomNode};
-use crate::dom::parser::PaNodeContainer;
 use crate::dom::{Dom, DomCreationError, UnicodeString};
-use crate::ListType;
-
-use super::padom_node::PaDomNode;
-use super::{PaDom, PaDomCreationError, PaDomCreator};
 
 pub fn parse<S>(html: &str) -> Result<Dom<S>, DomCreationError<S>>
 where
     S: UnicodeString,
 {
-    PaDomCreator::parse(html)
-        .map(padom_to_dom)
-        .map_err(padom_creation_error_to_dom_creation_error)
+    parse_inner(html)
 }
 
-/// Convert a [PaDom] into a [Dom].
-///
-/// [PaDom] is purely used within the parsing process (using html5ever) - in it,
-/// parents refer to their children by handles, and all the nodes are owned in
-/// a big list held by the PaDom itself. PaDoms may also contain garbage nodes
-/// that were created during parsing but are no longer needed. A garbage
-/// collection method was written for testing and is inside padom_creator's
-/// test code. The conversion process here ignores garbage nodes, so they do
-/// not appear in the final Dom.
-///
-/// [Dom] is for general use. Parent nodes own their children, and Dom may be
-/// cloned, compared, and converted into an HTML string.
-fn padom_to_dom<S>(padom: PaDom) -> Dom<S>
+#[cfg(all(feature = "sys", not(feature = "js")))]
+use sys::parse as parse_inner;
+
+#[cfg(all(feature = "js", not(feature = "sys")))]
+use js::parse as parse_inner;
+
+// This is just here to avoid an extra compilation error message when nor `sys`
+// nor `js` are enabled, or when both are enabled.
+#[cfg(any(
+    all(feature = "sys", feature = "js"),
+    all(not(feature = "sys"), not(feature = "js"))
+))]
+fn parse_inner<S>(_html: &str) -> Result<Dom<S>, DomCreationError<S>>
 where
     S: UnicodeString,
 {
-    /// Recurse into panode's children and convert them too
-    fn convert_children<S>(
-        padom: &PaDom,
-        child: &PaNodeContainer,
-        new_node: Option<&mut DomNode<S>>,
-    ) where
+    unreachable!("The `sys` or `js` are mutually exclusive, and one of them must be enabled.")
+}
+
+#[cfg(feature = "js")]
+mod js {
+    use super::*;
+
+    pub(super) fn parse<S>(_html: &str) -> Result<Dom<S>, DomCreationError<S>>
+    where
         S: UnicodeString,
     {
-        if let DomNode::Container(new_node) = new_node.unwrap() {
-            convert(padom, child, new_node);
+        unimplemented!()
+    }
+}
+
+#[cfg(feature = "sys")]
+mod sys {
+    use super::super::padom_node::PaDomNode;
+    use super::super::PaNodeContainer;
+    use super::super::{PaDom, PaDomCreationError, PaDomCreator};
+    use super::*;
+    use crate::dom::nodes::{ContainerNode, DomNode};
+    use crate::ListType;
+
+    pub(super) fn parse<S>(html: &str) -> Result<Dom<S>, DomCreationError<S>>
+    where
+        S: UnicodeString,
+    {
+        PaDomCreator::parse(html)
+            .map(padom_to_dom)
+            .map_err(padom_creation_error_to_dom_creation_error)
+    }
+
+    /// Convert a [PaDom] into a [Dom].
+    ///
+    /// [PaDom] is purely used within the parsing process (using html5ever) - in it,
+    /// parents refer to their children by handles, and all the nodes are owned in
+    /// a big list held by the PaDom itself. PaDoms may also contain garbage nodes
+    /// that were created during parsing but are no longer needed. A garbage
+    /// collection method was written for testing and is inside padom_creator's
+    /// test code. The conversion process here ignores garbage nodes, so they do
+    /// not appear in the final Dom.
+    ///
+    /// [Dom] is for general use. Parent nodes own their children, and Dom may be
+    /// cloned, compared, and converted into an HTML string.
+    pub(super) fn padom_to_dom<S>(padom: PaDom) -> Dom<S>
+    where
+        S: UnicodeString,
+    {
+        /// Recurse into panode's children and convert them too
+        fn convert_children<S>(
+            padom: &PaDom,
+            child: &PaNodeContainer,
+            new_node: Option<&mut DomNode<S>>,
+        ) where
+            S: UnicodeString,
+        {
+            if let DomNode::Container(new_node) = new_node.unwrap() {
+                convert(padom, child, new_node);
+            } else {
+                panic!("Container became non-container!");
+            }
+        }
+
+        /// Create a formatting node
+        fn new_formatting<S>(tag: &str) -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::Container(
+                ContainerNode::new_formatting_from_tag(tag.into(), Vec::new())
+                    .unwrap_or_else(|| panic!("Unknown format tag {}", tag)),
+            )
+        }
+
+        /// Create a br node
+        fn new_line_break<S>() -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::new_line_break()
+        }
+
+        /// Create a link node
+        fn new_link<S>(child: &PaNodeContainer) -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::Container(ContainerNode::new_link(
+                child.get_attr("href").unwrap_or("").into(),
+                Vec::new(),
+            ))
+        }
+
+        /// Create a list node
+        fn new_list<S>(tag: &str) -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::Container(ContainerNode::new_list(
+                ListType::try_from(S::from(tag)).unwrap(),
+                Vec::new(),
+            ))
+        }
+
+        /// Create a list item node
+        fn new_list_item<S>(tag: &str) -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::Container(ContainerNode::new_list_item(
+                tag.into(),
+                Vec::new(),
+            ))
+        }
+
+        /// Copy all panode's information into node (now we know it's a container).
+        fn convert_container<S>(
+            padom: &PaDom,
+            child: &PaNodeContainer,
+            node: &mut ContainerNode<S>,
+        ) where
+            S: UnicodeString,
+        {
+            let tag = child.name.local.as_ref();
+            match tag {
+                "b" | "code" | "del" | "em" | "i" | "strong" | "u" => {
+                    node.append_child(new_formatting(tag));
+                    convert_children(padom, child, node.last_child_mut());
+                }
+                "br" => {
+                    node.append_child(new_line_break());
+                }
+                "ol" | "ul" => {
+                    node.append_child(new_list(tag));
+                    convert_children(padom, child, node.last_child_mut());
+                }
+                "li" => {
+                    node.append_child(new_list_item(tag));
+                    convert_children(padom, child, node.last_child_mut());
+                }
+                "a" => {
+                    node.append_child(new_link(child));
+                    convert_children(padom, child, node.last_child_mut());
+                }
+                "html" => {
+                    // Skip the html tag - add its children to the
+                    // current node directly.
+                    convert(padom, child, node);
+                }
+                _ => {
+                    // Ignore tags we don't recognise
+                    // We should log - see internal task PSU-741
+                }
+            };
+        }
+
+        /// Copy all panode's information into node.
+        fn convert<S>(
+            padom: &PaDom,
+            panode: &PaNodeContainer,
+            node: &mut ContainerNode<S>,
+        ) where
+            S: UnicodeString,
+        {
+            for child_handle in &panode.children {
+                let child = padom.get_node(child_handle);
+                match child {
+                    PaDomNode::Container(child) => {
+                        convert_container(padom, child, node);
+                    }
+                    PaDomNode::Document(_) => {
+                        panic!("Found a document inside a document!")
+                    }
+                    PaDomNode::Text(text) => {
+                        node.append_child(DomNode::new_text(
+                            text.content.as_str().into(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut ret = Dom::new(Vec::new());
+        let doc = ret.document_mut();
+
+        if let PaDomNode::Document(padoc) = padom.get_document() {
+            convert(&padom, padoc, doc)
         } else {
-            panic!("Container became non-container!");
+            panic!("Document was not a document!");
+        }
+
+        ret
+    }
+
+    pub(super) fn padom_creation_error_to_dom_creation_error<S>(
+        e: PaDomCreationError,
+    ) -> DomCreationError<S>
+    where
+        S: UnicodeString,
+    {
+        DomCreationError {
+            dom: padom_to_dom(e.dom),
+            parse_errors: e.parse_errors,
         }
     }
 
-    /// Create a formatting node
-    fn new_formatting<S>(tag: &str) -> DomNode<S>
-    where
-        S: UnicodeString,
-    {
-        DomNode::Container(
-            ContainerNode::new_formatting_from_tag(tag.into(), Vec::new())
-                .unwrap_or_else(|| panic!("Unknown format tag {}", tag)),
-        )
-    }
+    #[cfg(test)]
+    mod test {
+        use speculoos::{assert_that, AssertionFailure, Spec};
+        use widestring::Utf16String;
 
-    /// Create a br node
-    fn new_line_break<S>() -> DomNode<S>
-    where
-        S: UnicodeString,
-    {
-        DomNode::new_line_break()
-    }
+        use crate::tests::testutils_composer_model::restore_whitespace;
+        use crate::ToHtml;
 
-    /// Create a link node
-    fn new_link<S>(child: &PaNodeContainer) -> DomNode<S>
-    where
-        S: UnicodeString,
-    {
-        DomNode::Container(ContainerNode::new_link(
-            child.get_attr("href").unwrap_or("").into(),
-            Vec::new(),
-        ))
-    }
+        use super::parse;
 
-    /// Create a list node
-    fn new_list<S>(tag: &str) -> DomNode<S>
-    where
-        S: UnicodeString,
-    {
-        DomNode::Container(ContainerNode::new_list(
-            ListType::try_from(S::from(tag)).unwrap(),
-            Vec::new(),
-        ))
-    }
+        trait Roundtrips<T> {
+            fn roundtrips(&self);
+        }
 
-    /// Create a list item node
-    fn new_list_item<S>(tag: &str) -> DomNode<S>
-    where
-        S: UnicodeString,
-    {
-        DomNode::Container(ContainerNode::new_list_item(tag.into(), Vec::new()))
-    }
-
-    /// Copy all panode's information into node (now we know it's a container).
-    fn convert_container<S>(
-        padom: &PaDom,
-        child: &PaNodeContainer,
-        node: &mut ContainerNode<S>,
-    ) where
-        S: UnicodeString,
-    {
-        let tag = child.name.local.as_ref();
-        match tag {
-            "b" | "code" | "del" | "em" | "i" | "strong" | "u" => {
-                node.append_child(new_formatting(tag));
-                convert_children(padom, child, node.last_child_mut());
-            }
-            "br" => {
-                node.append_child(new_line_break());
-            }
-            "ol" | "ul" => {
-                node.append_child(new_list(tag));
-                convert_children(padom, child, node.last_child_mut());
-            }
-            "li" => {
-                node.append_child(new_list_item(tag));
-                convert_children(padom, child, node.last_child_mut());
-            }
-            "a" => {
-                node.append_child(new_link(child));
-                convert_children(padom, child, node.last_child_mut());
-            }
-            "html" => {
-                // Skip the html tag - add its children to the
-                // current node directly.
-                convert(padom, child, node);
-            }
-            _ => {
-                // Ignore tags we don't recognise
-                // We should log - see internal task PSU-741
-            }
-        };
-    }
-
-    /// Copy all panode's information into node.
-    fn convert<S>(
-        padom: &PaDom,
-        panode: &PaNodeContainer,
-        node: &mut ContainerNode<S>,
-    ) where
-        S: UnicodeString,
-    {
-        for child_handle in &panode.children {
-            let child = padom.get_node(child_handle);
-            match child {
-                PaDomNode::Container(child) => {
-                    convert_container(padom, child, node);
-                }
-                PaDomNode::Document(_) => {
-                    panic!("Found a document inside a document!")
-                }
-                PaDomNode::Text(text) => {
-                    node.append_child(DomNode::new_text(
-                        text.content.as_str().into(),
-                    ));
+        impl<'s, T> Roundtrips<T> for Spec<'s, T>
+        where
+            T: AsRef<str>,
+        {
+            fn roundtrips(&self) {
+                let subject = self.subject.as_ref();
+                let dom = parse::<Utf16String>(subject).unwrap();
+                let output = restore_whitespace(&dom.to_html().to_string());
+                if output != subject {
+                    AssertionFailure::from_spec(self)
+                        .with_expected(String::from(subject))
+                        .with_actual(output)
+                        .fail();
                 }
             }
         }
-    }
 
-    let mut ret = Dom::new(Vec::new());
-    let doc = ret.document_mut();
-
-    if let PaDomNode::Document(padoc) = padom.get_document() {
-        convert(&padom, padoc, doc)
-    } else {
-        panic!("Document was not a document!");
-    }
-
-    ret
-}
-
-fn padom_creation_error_to_dom_creation_error<S>(
-    e: PaDomCreationError,
-) -> DomCreationError<S>
-where
-    S: UnicodeString,
-{
-    DomCreationError {
-        dom: padom_to_dom(e.dom),
-        parse_errors: e.parse_errors,
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use speculoos::{assert_that, AssertionFailure, Spec};
-    use widestring::Utf16String;
-
-    use crate::tests::testutils_composer_model::restore_whitespace;
-    use crate::ToHtml;
-
-    use super::parse;
-
-    trait Roundtrips<T> {
-        fn roundtrips(&self);
-    }
-
-    impl<'s, T> Roundtrips<T> for Spec<'s, T>
-    where
-        T: AsRef<str>,
-    {
-        fn roundtrips(&self) {
-            let subject = self.subject.as_ref();
-            let dom = parse::<Utf16String>(subject).unwrap();
-            let output = restore_whitespace(&dom.to_html().to_string());
-            if output != subject {
-                AssertionFailure::from_spec(self)
-                    .with_expected(String::from(subject))
-                    .with_actual(output)
-                    .fail();
-            }
+        #[test]
+        fn parse_plain_text() {
+            assert_that!("some text").roundtrips();
         }
-    }
 
-    #[test]
-    fn parse_plain_text() {
-        assert_that!("some text").roundtrips();
-    }
+        #[test]
+        fn parse_simple_tag() {
+            assert_that!("<strong>sdfds</strong>").roundtrips();
+        }
 
-    #[test]
-    fn parse_simple_tag() {
-        assert_that!("<strong>sdfds</strong>").roundtrips();
-    }
+        #[test]
+        fn parse_tag_with_surrounding_text() {
+            assert_that!("before <strong> within </strong> after").roundtrips();
+            assert_that!("before<strong>within</strong>after").roundtrips();
+        }
 
-    #[test]
-    fn parse_tag_with_surrounding_text() {
-        assert_that!("before <strong> within </strong> after").roundtrips();
-        assert_that!("before<strong>within</strong>after").roundtrips();
-    }
+        #[test]
+        fn parse_nested_tags() {
+            assert_that!("<b><em>ZZ</em></b>").roundtrips();
+            assert_that!("X<b>Y<em>ZZ</em>0</b>1").roundtrips();
+            assert_that!(" X <b> Y <em> ZZ </em> 0 </b> 1 ").roundtrips();
+        }
 
-    #[test]
-    fn parse_nested_tags() {
-        assert_that!("<b><em>ZZ</em></b>").roundtrips();
-        assert_that!("X<b>Y<em>ZZ</em>0</b>1").roundtrips();
-        assert_that!(" X <b> Y <em> ZZ </em> 0 </b> 1 ").roundtrips();
-    }
+        #[test]
+        fn parse_tags_with_attributes() {
+            assert_that!(r#"<b><a href="http://example.com">ZZ</a></b>"#)
+                .roundtrips();
+        }
 
-    #[test]
-    fn parse_tags_with_attributes() {
-        assert_that!(r#"<b><a href="http://example.com">ZZ</a></b>"#)
-            .roundtrips();
-    }
-
-    #[test]
-    fn parse_br_tag() {
-        assert_that!("<br />").roundtrips();
+        #[test]
+        fn parse_br_tag() {
+            assert_that!("<br />").roundtrips();
+        }
     }
 }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -18,26 +18,15 @@ pub fn parse<S>(html: &str) -> Result<Dom<S>, DomCreationError<S>>
 where
     S: UnicodeString,
 {
-    parse_inner(html)
-}
-
-#[cfg(all(feature = "sys", not(feature = "js")))]
-use sys::parse as parse_inner;
-
-#[cfg(all(feature = "js", not(feature = "sys")))]
-use js::parse as parse_inner;
-
-// This is just here to avoid an extra compilation error message when nor `sys`
-// nor `js` are enabled, or when both are enabled.
-#[cfg(any(
-    all(feature = "sys", feature = "js"),
-    all(not(feature = "sys"), not(feature = "js"))
-))]
-fn parse_inner<S>(_html: &str) -> Result<Dom<S>, DomCreationError<S>>
-where
-    S: UnicodeString,
-{
-    unreachable!("The `sys` or `js` are mutually exclusive, and one of them must be enabled.")
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sys")] {
+            sys::parse(html)
+        } else if #[cfg(feature = "js")] {
+            js::parse(html)
+        } else {
+            unreachable!("The `sys` or `js` are mutually exclusive, and one of them must be enabled.")
+        }
+    }
 }
 
 #[cfg(feature = "sys")]

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -466,7 +466,7 @@ mod js {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, target_arch = "wasm32"))]
     mod tests {
         use super::*;
         use crate::{

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -29,6 +29,7 @@ pub trait UnicodeString:
     + PartialEq
     + AsRef<[Self::CodeUnit]>
     + for<'a> From<&'a str>
+    + From<String>
     + Deref<Target = Self::Str>
     + for<'a> Extend<&'a Self::Str>
     + Extend<Self>

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(feature = "sys", feature = "js"))]
+compile_error!(
+    "The `sys` and `js` features are mutually exclusive. Please pick one."
+);
+
+#[cfg(all(not(feature = "sys"), not(feature = "js")))]
+compile_error!(
+    "At least the `sys` or `js` feature must be enabled. Please pick one."
+);
+
 mod composer_action;
 mod composer_model;
 mod composer_state;

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -12,16 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(feature = "sys", feature = "js"))]
-compile_error!(
-    "The `sys` and `js` features are mutually exclusive. Please pick one."
-);
-
-#[cfg(all(not(feature = "sys"), not(feature = "js")))]
-compile_error!(
-    "At least the `sys` or `js` feature must be enabled. Please pick one."
-);
-
 mod composer_action;
 mod composer_model;
 mod composer_state;

--- a/platforms/web/lib/useTestCases/utils.test.ts
+++ b/platforms/web/lib/useTestCases/utils.test.ts
@@ -235,10 +235,9 @@ describe('generateTestCase', () => {
             ['select', 2, 6],
         ];
 
-        // TODO: There is a bug in to_example_format in selections with entities
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'assert_eq!(tx(&model), ' +
             '"aa&lt;strong&gt;{bbbb}|&lt;/strong&gt;cc");\n';
 
@@ -263,10 +262,9 @@ describe('generateTestCase', () => {
             ['select', 3, 6],
         ];
 
-        // TODO: There is a bug in to_example_format in selections with entities
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.bold();\n' +
             'model.select(Location::from(3), Location::from(6));\n' +
             'assert_eq!(tx(&model), ' +
@@ -287,11 +285,9 @@ describe('generateTestCase', () => {
             ['select', 3, 0],
         ];
 
-        // TODO: There is a bug in to_example_format meaning the cursor
-        // is in the wrong place here.
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.bold();\n' +
             'model.select(Location::from(3), Location::from(0));\n' +
             'assert_eq!(tx(&model), ' +
@@ -312,10 +308,8 @@ describe('generateTestCase', () => {
             ['backspace'],
         ];
 
-        // TODO: There is a bug in to_example_format meaning the cursor
-        // is in the wrong place here. Internal id: PSU-839
         const expected =
-            'let mut model = cm("aa&lt;stron|g&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'let mut model = cm("aa&lt;st|rong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.backspace();\n' +
             'model.backspace();\n' +
             'assert_eq!(tx(&model), "aa&lt;stron|g&gt;bbbb&lt;/strong&gt;");\n';


### PR DESCRIPTION
With #214 and [Twiggy](https://github.com/rustwasm/twiggy), I've noticed that a large portion of the Wasm module comes from [`html5ever`](https://github.com/servo/html5ever/). This crate is used to parse HTML fragments and to build an `html5ever` specific DOM tree. This specific DOM tree is converted to a “`PaDom`” tree, which is then converted to a final `Dom` tree.

This PR adds a new Cargo feature to the `wysiwyg` crate: `js`. This feature instructs the library to **not** use `html5ever`, but to use a Web API to parse HTML fragment: `DOMParser`. Indeed, there is this neat function: [`DOMParser.parseFromString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString), which does exactly what we want! Instead of embedding a full HTML5 parser, inside a Wasm module, which will be executed inside an HTML browser, well… we can use the Web API provided by this same browser to do the same job.

Let's see how it goes so far. Before this patch, the Wasm module (compiled by `npm run build` from `bindings/wysiwyg-wasm/`) has a size of 522Kb. After this patch, the same Wasm module has a size of 123Kb.

~~This is still a draft PR because, at the time of writing, not all nodes are parsed: not because it's hard, but just because I wanted to test my approach :-).~~ 

To run the tests, use:

```sh
$  wasm-pack test --release --firefox --headless -- --no-default-features --features js -- parser::parse
```

I wanted to reuse the existing `parse::parse` tests, but `speculoos` is used, which depends on `num`, which depends on `rustc-serialize`, which doesn't compile to Wasm properly, sadly.

## Progress

- [x] Implement a new `js` feature on `wysiwyg`
- [x] Use the `DOMParser` Web API inside `dom::parser::parse`
- [x] Map to `Dom` for all nodes
- [x] Write tests
- [x] Update CI