### PR TITLE
[Android] Add plain text APIs

### DIFF
--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'androidx.test.espresso:espresso-accessibility:3.4.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.8'
+    testImplementation 'io.mockk:mockk:1.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -78,9 +78,10 @@ dependencies {
     implementation 'androidx.test.espresso:espresso-accessibility:3.4.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.8'
-    testImplementation 'io.mockk:mockk:1.13.2'
+    testImplementation 'io.mockk:mockk:1.12.5'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'io.mockk:mockk-android:1.12.5'
 }
 
 android.libraryVariants.all { variant ->

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -28,6 +28,8 @@ import io.element.android.wysiwyg.test.utils.ImeActions
 import io.element.android.wysiwyg.test.utils.TestActivity
 import io.element.android.wysiwyg.test.utils.selectionIsAt
 import org.hamcrest.Description
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.*
 import org.junit.runner.RunWith
 import uniffi.wysiwyg_composer.ComposerAction
@@ -271,6 +273,28 @@ class EditorEditTextInputTests {
             .perform(EditorActions.toggleFormat(InlineFormat.Italic))
 
         Assert.assertTrue(isItalicHighlighted)
+    }
+
+    @Test
+    fun testSetPlainText_ignoresHtml() {
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorEditText>(R.id.rich_text_edit_text)
+                .setPlainText("<b>$ipsum</b>")
+        }
+        onView(withId(R.id.rich_text_edit_text))
+            .check(matches(withText("<b>$ipsum</b>")))
+    }
+
+    @Test
+    fun testGetPlainText_stripsHtml() {
+        scenarioRule.scenario.onActivity {
+            val editText = it.findViewById<EditorEditText>(R.id.rich_text_edit_text)
+            editText.setHtml("<b>$ipsum</b>")
+
+            val plainText = editText.getPlainText()
+
+            assertThat(plainText, equalTo(ipsum))
+        }
     }
 
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/AndroidHtmlConverterTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/AndroidHtmlConverterTest.kt
@@ -1,0 +1,31 @@
+package io.element.android.wysiwyg.test.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.wysiwyg.utils.AndroidHtmlConverter
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AndroidHtmlConverterTest {
+    private val androidHtmlConverter = AndroidHtmlConverter
+
+    @Test
+    fun testToPlaintext_removesTags() {
+        val result = androidHtmlConverter.fromHtmlToPlainText(
+            "<b>Hello</b> <i>world</i>"
+        )
+
+        assertThat(result, equalTo("Hello world"))
+    }
+
+    @Test
+    fun testToPlaintext_handlesParagraphAndLineBreaks() {
+        val result = androidHtmlConverter.fromHtmlToPlainText(
+            "<p><b>Hello</b><br /><i>world</i></p>"
+        )
+
+        assertThat(result, equalTo("Hello\nworld\n\n"))
+    }
+}

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/AndroidHtmlConverterTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/AndroidHtmlConverterTest.kt
@@ -1,7 +1,11 @@
 package io.element.android.wysiwyg.test.utils
 
+import androidx.core.text.toSpanned
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.wysiwyg.utils.AndroidHtmlConverter
+import io.element.android.wysiwyg.utils.HtmlToSpansParser
+import io.mockk.every
+import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -9,10 +13,13 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AndroidHtmlConverterTest {
-    private val androidHtmlConverter = AndroidHtmlConverter
+    private val htmlToSpansParser = mockk<HtmlToSpansParser>()
+    private val androidHtmlConverter = AndroidHtmlConverter(
+        provideHtmlToSpansParser = { htmlToSpansParser }
+    )
 
     @Test
-    fun testToPlaintext_removesTags() {
+    fun testToPlainText_removesTags() {
         val result = androidHtmlConverter.fromHtmlToPlainText(
             "<b>Hello</b> <i>world</i>"
         )
@@ -21,11 +28,21 @@ class AndroidHtmlConverterTest {
     }
 
     @Test
-    fun testToPlaintext_handlesParagraphAndLineBreaks() {
+    fun testToPlainText_handlesLineBreaks() {
         val result = androidHtmlConverter.fromHtmlToPlainText(
             "<p><b>Hello</b><br /><i>world</i></p>"
         )
 
         assertThat(result, equalTo("Hello\nworld\n\n"))
+    }
+
+    @Test
+    fun testToSpans() {
+        val expectedParserOutput = "mock parser output".toSpanned()
+        every { htmlToSpansParser.convert() } returns expectedParserOutput
+
+        val result = androidHtmlConverter.fromHtmlToSpans("input")
+
+        assertThat(result, equalTo(expectedParserOutput))
     }
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
@@ -1,0 +1,119 @@
+package io.element.android.wysiwyg.test.utils
+
+import android.text.TextUtils
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.wysiwyg.utils.AndroidResourcesProvider
+import io.element.android.wysiwyg.utils.HtmlToSpansParser
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HtmlToSpansParserTest {
+    @Test
+    fun testStyles() {
+        val html = "<b>bold</b>" +
+                "<i>italic</i>" +
+                "<u>underline</u>" +
+                "<strong>strong</strong>" +
+                "<em>emphasis</em>" +
+                "<del>strikethrough</del>" +
+                "<code>code</code>"
+        val spanned = convertHtml(html)
+
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                listOf(
+                    "bold: android.text.style.StyleSpan (0-4) fl=#33",
+                    "italic: android.text.style.StyleSpan (4-10) fl=#33",
+                    "underline: android.text.style.UnderlineSpan (10-19) fl=#33",
+                    "strong: android.text.style.StyleSpan (19-25) fl=#33",
+                    "emphasis: android.text.style.StyleSpan (25-33) fl=#33",
+                    "strikethrough: android.text.style.StrikethroughSpan (33-46) fl=#33",
+                    "code: io.element.android.wysiwyg.spans.InlineCodeSpan (46-50) fl=#33",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testLists() {
+        val html = """
+            <ol>
+                <li>ordered1</li>
+                <li>ordered2</li>
+            </ol>
+            <ul>
+                <li>bullet1</li>
+                <li>bullet2</li>
+            </ul>
+        """.trimIndent()
+        val spanned = convertHtml(html)
+
+
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                listOf(
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200Bordered1: io.element.android.wysiwyg.spans.OrderedListSpan (0-9) fl=#33",
+                    "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (9-10) fl=#33",
+                    "ordered2: io.element.android.wysiwyg.spans.OrderedListSpan (10-18) fl=#33",
+                    "bullet1: android.text.style.BulletSpan (19-26) fl=#33",
+                    "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (26-27) fl=#33",
+                    "bullet2: android.text.style.BulletSpan (27-34) fl=#33"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testLineBreaks() {
+        val html = "Hello<br>world"
+        val spanned = convertHtml(html)
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                emptyList()
+            )
+        )
+        assertThat(
+            spanned.toString(), equalTo("Hello\nworld")
+        )
+    }
+
+    @Test
+    fun testIgnoresParagraphs() {
+        val html = "<p>Hello</p><br /><p>world</p>"
+        val spanned = convertHtml(html)
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                emptyList()
+            )
+        )
+        assertThat(
+            spanned.toString(), equalTo("Hello\nworld")
+        )
+    }
+
+    private fun CharSequence.dumpSpans(): List<String> {
+        val spans = mutableListOf<String>()
+        TextUtils.dumpSpans(
+            this, { span ->
+                val spanWithoutHash = span.split(" ").filterIndexed { index, _ ->
+                    index != 1
+                }.joinToString(" ")
+
+                spans.add(spanWithoutHash)
+            }, ""
+        )
+        return spans
+    }
+
+
+    private fun convertHtml(html: String) =
+        HtmlToSpansParser(
+            resourcesProvider = AndroidResourcesProvider(application = ApplicationProvider.getApplicationContext()),
+            html = html
+        ).convert()
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -20,9 +20,9 @@ import com.google.android.material.textfield.TextInputEditText
 import io.element.android.wysiwyg.inputhandlers.InterceptInputConnection
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
-import io.element.android.wysiwyg.utils.AndroidResourcesProvider
-import io.element.android.wysiwyg.utils.EditorIndexMapper
-import io.element.android.wysiwyg.utils.viewModel
+import io.element.android.wysiwyg.utils.*
+import io.element.android.wysiwyg.utils.AndroidHtmlConverter
+import io.element.android.wysiwyg.utils.HtmlToSpansParser
 import io.element.android.wysiwyg.viewmodel.EditorViewModel
 import uniffi.wysiwyg_composer.MenuState
 import uniffi.wysiwyg_composer.newComposerModel
@@ -33,8 +33,11 @@ class EditorEditText : TextInputEditText {
     private val viewModel: EditorViewModel by viewModel(viewModelInitializer = {
         val applicationContext = context.applicationContext as Application
         val resourcesProvider = AndroidResourcesProvider(applicationContext)
+        val htmlConverter = AndroidHtmlConverter(
+            provideHtmlToSpansParser = { html -> HtmlToSpansParser(resourcesProvider, html) },
+        )
         val composer = if(!isInEditMode) newComposerModel() else null
-        EditorViewModel(resourcesProvider, composer)
+        EditorViewModel(composer, htmlConverter)
     })
 
     private val spannableFactory = object : Spannable.Factory() {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -25,6 +25,7 @@ import io.element.android.wysiwyg.utils.EditorIndexMapper
 import io.element.android.wysiwyg.utils.viewModel
 import io.element.android.wysiwyg.viewmodel.EditorViewModel
 import uniffi.wysiwyg_composer.MenuState
+import uniffi.wysiwyg_composer.newComposerModel
 
 class EditorEditText : TextInputEditText {
 
@@ -32,7 +33,8 @@ class EditorEditText : TextInputEditText {
     private val viewModel: EditorViewModel by viewModel(viewModelInitializer = {
         val applicationContext = context.applicationContext as Application
         val resourcesProvider = AndroidResourcesProvider(applicationContext)
-        EditorViewModel(resourcesProvider, createComposer = !isInEditMode)
+        val composer = if(!isInEditMode) newComposerModel() else null
+        EditorViewModel(resourcesProvider, composer)
     })
 
     private val spannableFactory = object : Spannable.Factory() {
@@ -281,6 +283,22 @@ class EditorEditText : TextInputEditText {
     fun getHtmlOutput(): String {
         return viewModel.getHtml()
     }
+
+    /**
+     * Get the text as plain text (without any HTML formatting).
+     * Note that markdown is not currently supported.
+     * TODO: Return markdown formatted plain text
+     */
+    fun getPlainText(): String
+        = viewModel.getPlainText()
+
+    /**
+     * Set the text as plain text, ignoring HTML formatting.
+     * Note that markdown is not currently supported.
+     * TODO: Accept markdown formatted plain text
+     */
+    fun setPlainText(plainText: String) =
+        setText(plainText)
 
     private fun setSelectionFromComposerUpdate(start: Int, end: Int = start) {
         val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/RustExtensions.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/extensions/RustExtensions.kt
@@ -9,3 +9,9 @@ fun List<UShort>.string() = with(StringBuffer()) {
     }
     toString()
 }
+
+/**
+ * Translates a JVM String into a Rust [UShort] list.
+ */
+internal fun String.toUShortList(): List<UShort> = encodeToByteArray()
+    .map(Byte::toUShort)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
@@ -4,9 +4,12 @@ import androidx.core.text.HtmlCompat
 
 internal interface HtmlConverter {
     fun fromHtmlToPlainText(html: String): String
+    fun fromHtmlToSpans(html: String): CharSequence
 }
 
-internal object AndroidHtmlConverter: HtmlConverter {
+internal class AndroidHtmlConverter(
+    private val provideHtmlToSpansParser: (html: String) -> HtmlToSpansParser
+): HtmlConverter {
     /**
      * Get the content with formatting removed.
      * TODO: Return markdown formatted plaintext instead
@@ -15,4 +18,7 @@ internal object AndroidHtmlConverter: HtmlConverter {
         HtmlCompat.fromHtml(
             html, HtmlCompat.FROM_HTML_MODE_LEGACY
         ).toString()
+
+    override fun fromHtmlToSpans(html: String): CharSequence =
+        provideHtmlToSpansParser(html).convert()
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
@@ -1,0 +1,18 @@
+package io.element.android.wysiwyg.utils
+
+import androidx.core.text.HtmlCompat
+
+internal interface HtmlConverter {
+    fun fromHtmlToPlainText(html: String): String
+}
+
+internal object AndroidHtmlConverter: HtmlConverter {
+    /**
+     * Get the content with formatting removed.
+     * TODO: Return markdown formatted plaintext instead
+     */
+    override fun fromHtmlToPlainText(html: String): String =
+        HtmlCompat.fromHtml(
+            html, HtmlCompat.FROM_HTML_MODE_LEGACY
+        ).toString()
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -1,6 +1,5 @@
 package io.element.android.wysiwyg.utils
 
-import android.content.Context
 import android.graphics.Typeface
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
@@ -29,7 +28,7 @@ import kotlin.math.roundToInt
  * This is specially important for lists, since they not only use custom spans, but they also need
  * to create [ExtraCharacterSpan] spans to work properly.
  */
-class HtmlToSpansParser(
+internal class HtmlToSpansParser(
     private val resourcesProvider: ResourcesProvider,
     private val html: String,
 ): ContentHandler {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
@@ -1,7 +1,6 @@
 package io.element.android.wysiwyg.viewmodel
 
 import android.text.Editable
-import android.text.Spanned
 import androidx.lifecycle.ViewModel
 import io.element.android.wysiwyg.BuildConfig
 import io.element.android.wysiwyg.extensions.log
@@ -16,9 +15,8 @@ import uniffi.wysiwyg_composer.MenuState
 import uniffi.wysiwyg_composer.TextUpdate
 
 internal class EditorViewModel(
-    private val resourcesProvider: ResourcesProvider,
     private val composer: ComposerModelInterface?,
-    private val htmlConverter: HtmlConverter = AndroidHtmlConverter,
+    private val htmlConverter: HtmlConverter,
 ) : ViewModel() {
 
     private var menuStateCallback: ((MenuState) -> Unit)? = null
@@ -116,8 +114,7 @@ internal class EditorViewModel(
         return composer?.getCurrentMenuState() as? MenuState.Update
     }
 
-    private fun stringToSpans(string: String): Spanned {
-        return HtmlToSpansParser(resourcesProvider, string).convert()
-    }
+    private fun stringToSpans(string: String): CharSequence =
+        htmlConverter.fromHtmlToSpans(string)
 
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/BasicHtmlConverter.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/BasicHtmlConverter.kt
@@ -1,0 +1,9 @@
+package io.element.android.wysiwyg.utils
+
+/**
+ * HTML converter that is not depend on Android, for unit tests.
+ */
+class BasicHtmlConverter: HtmlConverter {
+    override fun fromHtmlToPlainText(html: String): String =
+        html.replace("<[^>]*>".toRegex(), "")
+}

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/BasicHtmlConverter.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/BasicHtmlConverter.kt
@@ -6,4 +6,7 @@ package io.element.android.wysiwyg.utils
 class BasicHtmlConverter: HtmlConverter {
     override fun fromHtmlToPlainText(html: String): String =
         html.replace("<[^>]*>".toRegex(), "")
+
+    override fun fromHtmlToSpans(html: String): CharSequence =
+        fromHtmlToPlainText(html)
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -12,11 +12,9 @@ import uniffi.wysiwyg_composer.ComposerModelInterface
 
 internal class EditorViewModelTest {
 
-    private val resourcesProvider = mockk<ResourcesProvider>()
     private val composer = mockk<ComposerModelInterface>()
     private val htmlConverter = BasicHtmlConverter()
     private val viewModel = EditorViewModel(
-        resourcesProvider = resourcesProvider,
         composer = composer,
         htmlConverter = htmlConverter,
     )

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -1,0 +1,55 @@
+package io.element.android.wysiwyg.viewmodel
+
+import io.element.android.wysiwyg.extensions.toUShortList
+import io.element.android.wysiwyg.utils.BasicHtmlConverter
+import io.element.android.wysiwyg.utils.ResourcesProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import uniffi.wysiwyg_composer.ComposerModelInterface
+
+internal class EditorViewModelTest {
+
+    private val resourcesProvider = mockk<ResourcesProvider>()
+    private val composer = mockk<ComposerModelInterface>()
+    private val htmlConverter = BasicHtmlConverter()
+    private val viewModel = EditorViewModel(
+        resourcesProvider = resourcesProvider,
+        composer = composer,
+        htmlConverter = htmlConverter,
+    )
+
+    companion object {
+        private const val paragraph =
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry."
+        private const val htmlParagraphs =
+            "<p><b>$paragraph</b></p>" +
+                    "<p><i>$paragraph</i></p>"
+        private const val plainTextParagraphs = "$paragraph$paragraph"
+    }
+
+    @Test
+    fun `given formatted text, getHtml returns formatted HTML`() {
+        givenComposerHtml(htmlParagraphs)
+
+        val html = viewModel.getHtml()
+
+        assertThat(html, equalTo(htmlParagraphs))
+    }
+
+    @Test
+    fun `given formatted text, getPlainText returns plain text`() {
+        givenComposerHtml(htmlParagraphs)
+
+        val plainText = viewModel.getPlainText()
+
+        assertThat(plainText, equalTo(plainTextParagraphs))
+    }
+
+    private fun givenComposerHtml(composerHtml: String) =
+        every { composer.getCurrentDomState() } returns mockk {
+            every { html } returns composerHtml.toUShortList()
+        }
+}


### PR DESCRIPTION
[`PSU-780`](https://element-io.atlassian.net/browse/PSU-780)

Adds two a new public APIs to the `EditorEditText`:

### `EditorEditText#setPlainText`
Set the text without interpretting HTML formatting. In future, this can be extended to accept markdown formatted plain text. 

### `EditorEditText#getPlainText`
Get the text without any HTML formatting. In future, this can be extended to return markdown formatted plain text.
