### PR TITLE
fix(wysiwyg): Merge sequential text nodes when parsing

### DIFF
--- a/platforms/web/lib/useTestCases/utils.test.ts
+++ b/platforms/web/lib/useTestCases/utils.test.ts
@@ -235,10 +235,9 @@ describe('generateTestCase', () => {
             ['select', 2, 6],
         ];
 
-        // TODO: There is a bug in to_example_format in selections with entities
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'assert_eq!(tx(&model), ' +
             '"aa&lt;strong&gt;{bbbb}|&lt;/strong&gt;cc");\n';
 
@@ -263,10 +262,9 @@ describe('generateTestCase', () => {
             ['select', 3, 6],
         ];
 
-        // TODO: There is a bug in to_example_format in selections with entities
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.bold();\n' +
             'model.select(Location::from(3), Location::from(6));\n' +
             'assert_eq!(tx(&model), ' +
@@ -287,11 +285,9 @@ describe('generateTestCase', () => {
             ['select', 3, 0],
         ];
 
-        // TODO: There is a bug in to_example_format meaning the cursor
-        // is in the wrong place here.
         const expected =
             'let mut model = ' +
-            'cm("aa{&lt;str}|ong&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'cm("aa{&lt;}|strong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.bold();\n' +
             'model.select(Location::from(3), Location::from(0));\n' +
             'assert_eq!(tx(&model), ' +
@@ -312,10 +308,8 @@ describe('generateTestCase', () => {
             ['backspace'],
         ];
 
-        // TODO: There is a bug in to_example_format meaning the cursor
-        // is in the wrong place here. Internal id: PSU-839
         const expected =
-            'let mut model = cm("aa&lt;stron|g&gt;bbbb&lt;/strong&gt;cc");\n' +
+            'let mut model = cm("aa&lt;st|rong&gt;bbbb&lt;/strong&gt;cc");\n' +
             'model.backspace();\n' +
             'model.backspace();\n' +
             'assert_eq!(tx(&model), "aa&lt;stron|g&gt;bbbb&lt;/strong&gt;");\n';


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-wysiwyg/issues/242.

When `html5ever` produces multiple text nodes (`PaDomNode::Text`) sequentially, the DOM tree was sub-optimal. It happens for example when a text node contains HTML escaped entites. For example:

```rust
let model = ComposerModel::<Utf16String>::from_html(
    "aa&lt;strong&gt;bbbb&lt;/strong&gt;cc",
    0,
    0,
);
```

produces this DOM tree:

```
Dom {
  document: Container(
      ContainerNode {
          name: "",
          kind: Generic,
          attrs: None,
          children: [
              Text(
                  TextNode {
                      data: "aa",
                      handle: DomHandle {
                          path: Some(
                              [
                                  0,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "<",
                      handle: DomHandle {
                          path: Some(
                              [
                                  1,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "s",
                      handle: DomHandle {
                          path: Some(
                              [
                                  2,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "trong",
                      handle: DomHandle {
                          path: Some(
                              [
                                  3,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: ">",
                      handle: DomHandle {
                          path: Some(
                              [
                                  4,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "b",
                      handle: DomHandle {
                          path: Some(
                              [
                                  5,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "bbb",
                      handle: DomHandle {
                          path: Some(
                              [
                                  6,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "<",
                      handle: DomHandle {
                          path: Some(
                              [
                                  7,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "/",
                      handle: DomHandle {
                          path: Some(
                              [
                                  8,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "strong",
                      handle: DomHandle {
                          path: Some(
                              [
                                  9,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: ">",
                      handle: DomHandle {
                          path: Some(
                              [
                                  10,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "c",
                      handle: DomHandle {
                          path: Some(
                              [
                                  11,
                              ],
                          ),
                      },
                  },
              ),
              Text(
                  TextNode {
                      data: "c",
                      handle: DomHandle {
                          path: Some(
                              [
                                  12,
                              ],
                          ),
                      },
                  },
              ),
          ],
          handle: DomHandle {
              path: Some(
                  [],
              ),
          },
      },
  ),
}
```

The weird cutting can be explained by the way `Tendril` works I guess.

This patch updates the `TreeSink` implementation of `PaDomCreator` to merge a text node with a previous text node if it exists. Otherwise it creates a new node. That was the intent of the previous code, but with a bug. To find the last text node to merge with, we must find the previous text node in the parent container node if it is at a last position.

To avoid making the borrow checker unhappy by borrowing `self` once immutably, and once mutably, this patch splits this in two steps, thus replacing the `add_node` variable.

The new resulting DOM tree is the following:

```
Dom {
    document: Container(
        ContainerNode {
            name: "",
            kind: Generic,
            attrs: None,
            children: [
                Text(
                    TextNode {
                        data: "aa<strong>bbbb</strong>cc",
                        handle: DomHandle {
                            path: Some(
                                [
                                    0,
                                ],
                            ),
                        },
                    },
                ),
            ],
            handle: DomHandle {
                path: Some(
                    [],
                ),
            },
        },
    ),
}
```

which is much better from my point of view :-). 


Finally, a new test has been created to ensure this behavior is now fixed.