### PR TITLE
iOS: Fixing missing keystroke bug + long press delete issue

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -34,11 +34,11 @@ struct Composer: View {
             HStack {
                 WysiwygComposerView(
                     focused: $focused,
-                    content: viewModel.content,
                     replaceText: viewModel.replaceText,
                     select: viewModel.select,
                     didUpdateText: viewModel.didUpdateText,
-                    updateCompressedHeightIfNeeded: viewModel.updateCompressedHeightIfNeeded
+                    updateCompressedHeightIfNeeded: viewModel.updateCompressedHeightIfNeeded,
+                    viewModel: viewModel
                 )
                 .placeholder("Placeholder", color: .gray)
                 .frame(height: viewModel.idealHeight)

--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -34,10 +34,6 @@ struct Composer: View {
             HStack {
                 WysiwygComposerView(
                     focused: $focused,
-                    replaceText: viewModel.replaceText,
-                    select: viewModel.select,
-                    didUpdateText: viewModel.didUpdateText,
-                    updateCompressedHeightIfNeeded: viewModel.updateCompressedHeightIfNeeded,
                     viewModel: viewModel
                 )
                 .placeholder("Placeholder", color: .gray)

--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -37,7 +37,8 @@ struct Composer: View {
                     content: viewModel.content,
                     replaceText: viewModel.replaceText,
                     select: viewModel.select,
-                    didUpdateText: viewModel.didUpdateText
+                    didUpdateText: viewModel.didUpdateText,
+                    updateCompressedHeightIfNeeded: viewModel.updateCompressedHeightIfNeeded
                 )
                 .placeholder("Placeholder", color: .gray)
                 .frame(height: viewModel.idealHeight)

--- a/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
@@ -116,6 +116,35 @@ final class WysiwygSharedTests {
         XCTAssertEqual(content.label, "Some bold text")
         XCTAssertEqual(htmlContent.label, "Some bold <strong>text</strong>")
     }
+    
+    static func typingFast(_ app: XCUIApplication) throws {
+        let text = "Some long text that I am going to type very fast"
+        let textView = app.textViews["WysiwygComposer"]
+        app.typeText(text)
+        let textToVerify = textView.value as? String
+        XCTAssert(text == textToVerify)
+    }
+    
+    static func longPressDelete(_ app: XCUIApplication) throws {
+        let multilineText =
+            """
+            test1
+            test2
+            test3
+            test4
+            test5
+            test6
+            test7
+            test8
+            test9
+            test10
+            """
+        let textView = app.textViews["WysiwygComposer"]
+        app.typeTextCharByChar(multilineText)
+        XCUIApplication().keys["delete"].press(forDuration: 10.0)
+        let resultText = textView.value as? String
+        XCTAssert(resultText == "")
+    }
 }
 
 private extension WysiwygSharedTests {

--- a/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
@@ -120,7 +120,7 @@ final class WysiwygSharedTests {
     static func typingFast(_ app: XCUIApplication) throws {
         let text = "Some long text that I am going to type very fast"
         let textView = app.textViews["WysiwygComposer"]
-        app.typeText(text)
+        textView.typeText(text)
         let textToVerify = textView.value as? String
         XCTAssert(text == textToVerify)
     }

--- a/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
@@ -120,6 +120,7 @@ final class WysiwygSharedTests {
     static func typingFast(_ app: XCUIApplication) throws {
         let text = "Some long text that I am going to type very fast"
         let textView = app.textViews["WysiwygComposer"]
+        textView.tap()
         textView.typeText(text)
         let textToVerify = textView.value as? String
         XCTAssert(text == textToVerify)

--- a/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygSharedTests.swift
@@ -121,6 +121,7 @@ final class WysiwygSharedTests {
         let text = "Some long text that I am going to type very fast"
         let textView = app.textViews["WysiwygComposer"]
         textView.tap()
+        sleep(1)
         textView.typeText(text)
         let textToVerify = textView.value as? String
         XCTAssert(text == textToVerify)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -40,9 +40,10 @@ class WysiwygUITests: XCTestCase {
         try WysiwygSharedTests.typeAndSendMessage(app)
     }
     
-//    func testTypingFast() throws {
-//        try WysiwygSharedTests.typingFast(app)
-//    }
+    // Remember to disable hardware keyboard and use only software keyboard for this UITest
+    func testTypingFast() throws {
+        try WysiwygSharedTests.typingFast(app)
+    }
     
     func testLongPressDelete() throws {
         try WysiwygSharedTests.longPressDelete(app)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -39,4 +39,12 @@ class WysiwygUITests: XCTestCase {
     func testTypingAndSending() throws {
         try WysiwygSharedTests.typeAndSendMessage(app)
     }
+    
+//    func testTypingFast() throws {
+//        try WysiwygSharedTests.typingFast(app)
+//    }
+    
+    func testLongPressDelete() throws {
+        try WysiwygSharedTests.longPressDelete(app)
+    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/PlaceholdableTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/PlaceholdableTextView.swift
@@ -17,6 +17,12 @@
 import UIKit
 
 public class PlaceholdableTextView: UITextView {
+    var shouldShowPlaceholder = true {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
     var placeholder: String? {
         didSet {
             setNeedsDisplay()
@@ -48,7 +54,7 @@ public class PlaceholdableTextView: UITextView {
     override public func draw(_ rect: CGRect) {
         super.draw(rect)
         
-        guard attributedText.length == 0, let placeholder = placeholder else {
+        guard shouldShowPlaceholder, let placeholder = placeholder else {
             return
         }
         

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -16,9 +16,8 @@
 
 import Foundation
 
-@objcMembers
 /// Defines message content displayed in the composer.
-public class WysiwygComposerContent: NSObject {
+public struct WysiwygComposerContent {
     // MARK: - Public
 
     /// Displayed text, as plain text.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -17,7 +17,8 @@
 import Foundation
 
 /// Defines message content displayed in the composer.
-public struct WysiwygComposerContent {
+@objcMembers
+public class WysiwygComposerContent: NSObject {
     // MARK: - Public
 
     /// Displayed text, as plain text.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -21,15 +21,14 @@ import SwiftUI
 public struct WysiwygComposerView: UIViewRepresentable {
     // MARK: - Internal
 
-    public var viewModel: WysiwygComposerViewModel
-    
+    private var viewModel: WysiwygComposerViewModelProtocol
     private var tintColor = Color.accentColor
     private var placeholderColor = Color(UIColor.placeholderText)
     private var placeholder: String?
     @Binding public var focused: Bool
 
     public init(focused: Binding<Bool>,
-                viewModel: WysiwygComposerViewModel) {
+                viewModel: WysiwygComposerViewModelProtocol) {
         _focused = focused
         self.viewModel = viewModel
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -25,7 +25,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     public var select: (NSAttributedString, NSRange) -> Void
     public var didUpdateText: (UITextView) -> Void
     public var updateCompressedHeightIfNeeded: (UITextView) -> Void
-    @ObservedObject public var viewModel: WysiwygComposerViewModel
+    public var viewModel: WysiwygComposerViewModel
     
     private var tintColor = Color.accentColor
     private var placeholderColor = Color(UIColor.placeholderText)
@@ -69,7 +69,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     }
 
     public func updateUIView(_ uiView: PlaceholdableTextView, context: Context) {
-        didUpdateText(uiView)
+        updateCompressedHeightIfNeeded(uiView)
         uiView.tintColor = UIColor(tintColor)
         uiView.placeholderColor = UIColor(placeholderColor)
         uiView.placeholder = placeholder
@@ -124,6 +124,10 @@ public struct WysiwygComposerView: UIViewRepresentable {
         
         public func textViewDidEndEditing(_ textView: UITextView) {
             focused.wrappedValue = false
+        }
+        
+        public func textViewDidChange(_ textView: UITextView) {
+            didUpdateText(textView)
         }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -65,11 +65,11 @@ public struct WysiwygComposerView: UIViewRepresentable {
         textView.placeholderColor = UIColor(placeholderColor)
         textView.placeholder = placeholder
         viewModel.textView = textView
+        updateCompressedHeightIfNeeded(textView)
         return textView
     }
 
     public func updateUIView(_ uiView: PlaceholdableTextView, context: Context) {
-        updateCompressedHeightIfNeeded(uiView)
         uiView.tintColor = UIColor(tintColor)
         uiView.placeholderColor = UIColor(placeholderColor)
         uiView.placeholder = placeholder
@@ -115,7 +115,9 @@ public struct WysiwygComposerView: UIViewRepresentable {
         public func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
                                      functionName: #function)
-            select(textView.attributedText, textView.selectedRange)
+            DispatchQueue.main.async {
+                self.select(textView.attributedText, textView.selectedRange)
+            }
         }
         
         public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -118,6 +118,8 @@ public struct WysiwygComposerView: UIViewRepresentable {
         public func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
                                      functionName: #function)
+            // This solves the race condition happening between did update text and the select function
+            // While deleting with a long press
             DispatchQueue.main.async {
                 self.select(textView.attributedText, textView.selectedRange)
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -100,6 +100,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
         public func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
                                      functionName: #function)
+            // Fixes long press delete issue
             DispatchQueue.main.async {
                 self.select(textView.attributedText, textView.selectedRange)
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -61,7 +61,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
         Logger.textView.logDebug(
             [
                 viewModel.content.logAttributedSelection,
-                viewModel.content.logText
+                viewModel.content.logText,
             ],
             functionName: #function
         )
@@ -108,7 +108,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
             Logger.textView.logDebug(
                 [
                     textView.logSelection,
-                    textView.logText
+                    textView.logText,
                 ],
                 functionName: #function
             )

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -58,6 +58,13 @@ public struct WysiwygComposerView: UIViewRepresentable {
     }
 
     public func updateUIView(_ uiView: PlaceholdableTextView, context: Context) {
+        Logger.textView.logDebug(
+            [
+                viewModel.content.logAttributedSelection,
+                viewModel.content.logText
+            ],
+            functionName: #function
+        )
         uiView.tintColor = UIColor(tintColor)
         uiView.placeholderColor = UIColor(placeholderColor)
         uiView.placeholder = placeholder
@@ -96,6 +103,17 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                      functionName: #function)
             return replaceText(textView, range, text)
         }
+        
+        public func textViewDidChange(_ textView: UITextView) {
+            Logger.textView.logDebug(
+                [
+                    textView.logSelection,
+                    textView.logText
+                ],
+                functionName: #function
+            )
+            didUpdateText(textView)
+        }
 
         public func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
@@ -112,10 +130,6 @@ public struct WysiwygComposerView: UIViewRepresentable {
         
         public func textViewDidEndEditing(_ textView: UITextView) {
             focused.wrappedValue = false
-        }
-        
-        public func textViewDidChange(_ textView: UITextView) {
-            didUpdateText(textView)
         }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -21,10 +21,6 @@ import SwiftUI
 public struct WysiwygComposerView: UIViewRepresentable {
     // MARK: - Internal
 
-    public var replaceText: (UITextView, NSRange, String) -> Bool
-    public var select: (NSAttributedString, NSRange) -> Void
-    public var didUpdateText: (UITextView) -> Void
-    public var updateCompressedHeightIfNeeded: (UITextView) -> Void
     public var viewModel: WysiwygComposerViewModel
     
     private var tintColor = Color.accentColor
@@ -33,15 +29,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     @Binding public var focused: Bool
 
     public init(focused: Binding<Bool>,
-                replaceText: @escaping (UITextView, NSRange, String) -> Bool,
-                select: @escaping (NSAttributedString, NSRange) -> Void,
-                didUpdateText: @escaping (UITextView) -> Void,
-                updateCompressedHeightIfNeeded: @escaping (UITextView) -> Void,
                 viewModel: WysiwygComposerViewModel) {
-        self.replaceText = replaceText
-        self.select = select
-        self.didUpdateText = didUpdateText
-        self.updateCompressedHeightIfNeeded = updateCompressedHeightIfNeeded
         _focused = focused
         self.viewModel = viewModel
     }
@@ -65,7 +53,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
         textView.placeholderColor = UIColor(placeholderColor)
         textView.placeholder = placeholder
         viewModel.textView = textView
-        updateCompressedHeightIfNeeded(textView)
+        viewModel.updateCompressedHeightIfNeeded(textView)
         return textView
     }
 
@@ -82,7 +70,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     }
 
     public func makeCoordinator() -> Coordinator {
-        Coordinator($focused, replaceText, select, didUpdateText, updateCompressedHeightIfNeeded)
+        Coordinator($focused, viewModel.replaceText, viewModel.select, viewModel.didUpdateText)
     }
 
     /// Coordinates UIKit communication.
@@ -91,17 +79,14 @@ public struct WysiwygComposerView: UIViewRepresentable {
         var replaceText: (UITextView, NSRange, String) -> Bool
         var select: (NSAttributedString, NSRange) -> Void
         var didUpdateText: (UITextView) -> Void
-        var updateCompressedHeightIfNeeded: (UITextView) -> Void
         init(_ focused: Binding<Bool>,
              _ replaceText: @escaping (UITextView, NSRange, String) -> Bool,
              _ select: @escaping (NSAttributedString, NSRange) -> Void,
-             _ didUpdateText: @escaping (UITextView) -> Void,
-             _ updateCompressedHeightIfNeeded: @escaping (UITextView) -> Void) {
+             _ didUpdateText: @escaping (UITextView) -> Void) {
             self.focused = focused
             self.replaceText = replaceText
             self.select = select
             self.didUpdateText = didUpdateText
-            self.updateCompressedHeightIfNeeded = updateCompressedHeightIfNeeded
         }
 
         public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -118,7 +118,9 @@ public struct WysiwygComposerView: UIViewRepresentable {
         public func textViewDidChangeSelection(_ textView: UITextView) {
             Logger.textView.logDebug([textView.logSelection],
                                      functionName: #function)
-            select(textView.attributedText, textView.selectedRange)
+            DispatchQueue.main.async {
+                self.select(textView.attributedText, textView.selectedRange)
+            }
         }
         
         public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -195,7 +195,7 @@ public extension WysiwygComposerViewModel {
     /// Replace text in the model.
     ///
     /// - Parameters:
-    ///   - text: Text currently displayed in the composer.
+    ///   - textView: TextView which currently holds the displayed text in the composer.
     ///   - range: Range to replace.
     ///   - replacementText: Replacement text to apply.
     func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -23,6 +23,8 @@ import UIKit
 public class WysiwygComposerViewModel: ObservableObject {
     // MARK: - Public
 
+    /// The textView with placeholder support that the model manages
+    public var textView: PlaceholdableTextView!
     /// Published object for the composer content.
     @Published public var content: WysiwygComposerContent = .init()
     /// Published boolean for the composer empty content state.
@@ -47,8 +49,6 @@ public class WysiwygComposerViewModel: ObservableObject {
             updatePlainTextMode(plainTextMode)
         }
     }
-
-    public var textView: PlaceholdableTextView?
     
     /// The current textColor of the attributed string
     public var textColor: UIColor {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -412,16 +412,3 @@ private extension WysiwygComposerViewModel {
 private extension Logger {
     static let viewModel = Logger(subsystem: subsystem, category: "ViewModel")
 }
-
-// MARK: - Utils
-
-private extension NSAttributedString {
-    func changeColor(to color: UIColor) -> NSAttributedString {
-        let mutableAttributed = NSMutableAttributedString(attributedString: self)
-        mutableAttributed.addAttributes(
-            [.foregroundColor: color], range: NSRange(location: 0, length: mutableAttributed.length)
-        )
-        let newSelf = NSAttributedString(attributedString: mutableAttributed)
-        return newSelf
-    }
-}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -171,6 +171,8 @@ public class WysiwygComposerViewModel: ObservableObject {
             update = model.unorderedList()
         }
         applyUpdate(update)
+        guard let textView = textView else { return }
+        didUpdateText(textView: textView)
     }
 
     /// Sets given HTML as the current content of the composer.
@@ -180,11 +182,15 @@ public class WysiwygComposerViewModel: ObservableObject {
     public func setHtmlContent(_ html: String) {
         let update = model.replaceAllHtml(html: html)
         applyUpdate(update)
+        guard let textView = textView else { return }
+        didUpdateText(textView: textView)
     }
 
     /// Clear the content of the composer.
     public func clearContent() {
         applyUpdate(model.clear())
+        guard let textView = textView else { return }
+        didUpdateText(textView: textView)
     }
 
     /// Returns a textual representation of the composer model as a tree.
@@ -217,7 +223,6 @@ public extension WysiwygComposerViewModel {
         if content.attributedSelection.length == 0, replacementText == "" {
             Logger.viewModel.logDebug(["Ignored an empty replacement"],
                                       functionName: #function)
-            didUpdateText(textView: textView)
             return false
         }
 
@@ -294,8 +299,6 @@ private extension WysiwygComposerViewModel {
                          disabledActions: disabledActions):
             self.reversedActions = reversedActions
             self.disabledActions = disabledActions
-            guard let textView = textView else { return }
-            didUpdateText(textView: textView)
         default:
             break
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -54,9 +54,9 @@ public class WysiwygComposerViewModel: ObservableObject {
     public var textColor: UIColor {
         didSet {
             // In case of a color change, this will refresh the attributed text
-            guard let textView = textView else { return }
             let update = model.replaceAllHtml(html: content.html)
             applyUpdate(update)
+            guard let textView = textView else { return }
             didUpdateText(textView: textView)
         }
     }
@@ -109,8 +109,8 @@ public class WysiwygComposerViewModel: ObservableObject {
     /// Apply any additional setup required.
     /// Should be called when the view appears.
     public func setup() {
-        guard let textView = textView else { return }
         applyUpdate(model.replaceAllHtml(html: ""))
+        guard let textView = textView else { return }
         didUpdateText(textView: textView)
     }
     

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -206,8 +206,8 @@ public extension WysiwygComposerViewModel {
         let update: ComposerUpdate
         let shouldAcceptChange: Bool
 
-        if range != content.attributedSelection {
-            select(text: textView.attributedText!, range: range)
+        if range != content.attributedSelection, let text = textView.attributedText {
+            select(text: text, range: range)
         }
 
         if content.attributedSelection.length == 0, replacementText == "" {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -169,12 +169,12 @@ public extension WysiwygComposerViewModel {
     ///   - text: Text currently displayed in the composer.
     ///   - range: Range to replace.
     ///   - replacementText: Replacement text to apply.
-    func replaceText(_ text: NSAttributedString, range: NSRange, replacementText: String) -> Bool {
+    func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool {
         let update: ComposerUpdate
         let shouldAcceptChange: Bool
 
         if range != content.attributedSelection {
-            select(text: text, range: range)
+            select(text: textView.attributedText!, range: range)
         }
 
         if content.attributedSelection.length == 0, replacementText == "" {
@@ -192,6 +192,9 @@ public extension WysiwygComposerViewModel {
         }
 
         applyUpdate(update)
+        if !shouldAcceptChange {
+            textView.apply(content)
+        }
         return shouldAcceptChange
     }
 
@@ -207,6 +210,20 @@ public extension WysiwygComposerViewModel {
         }
 
         updateCompressedHeightIfNeeded(textView)
+    }
+    
+    /// Update the composer compressed required height if it has changed.
+    ///
+    /// - Parameters:
+    ///   - textView: The composer's text view.
+    func updateCompressedHeightIfNeeded(_ textView: UITextView) {
+        let idealTextHeight = textView
+            .sizeThatFits(CGSize(width: textView.bounds.size.width,
+                                 height: CGFloat.greatestFiniteMagnitude)
+            )
+            .height
+        
+        compressedHeight = min(maxHeight, max(minHeight, idealTextHeight))
     }
 }
 
@@ -299,20 +316,6 @@ private extension WysiwygComposerViewModel {
                                        "Error: \(error.localizedDescription)"],
                                       functionName: #function)
         }
-    }
-
-    /// Update the composer compressed required height if it has changed.
-    ///
-    /// - Parameters:
-    ///   - textView: The composer's text view.
-    func updateCompressedHeightIfNeeded(_ textView: UITextView) {
-        let idealTextHeight = textView
-            .sizeThatFits(CGSize(width: textView.bounds.size.width,
-                                 height: CGFloat.greatestFiniteMagnitude)
-            )
-            .height
-        
-        compressedHeight = min(maxHeight, max(minHeight, idealTextHeight))
     }
     
     /// Update the composer ideal height based on the maximised state.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -173,6 +173,7 @@ public extension WysiwygComposerViewModel {
     ///   - replacementText: Replacement text to apply.
     func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool {
         let update: ComposerUpdate
+        let shouldAcceptChange: Bool
 
         if range != content.attributedSelection {
             select(text: textView.attributedText!, range: range)
@@ -186,12 +187,17 @@ public extension WysiwygComposerViewModel {
 
         if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
             update = model.enter()
+            shouldAcceptChange = false
         } else {
             update = model.replaceText(newText: replacementText)
+            shouldAcceptChange = true
         }
 
         applyUpdate(update)
-        return false
+        if !shouldAcceptChange {
+            didUpdateText(textView: textView)
+        }
+        return shouldAcceptChange
     }
 
     /// Notify that the text view content has changed.
@@ -247,6 +253,8 @@ private extension WysiwygComposerViewModel {
                          disabledActions: disabledActions):
             self.reversedActions = reversedActions
             self.disabledActions = disabledActions
+            guard let textView = textView else { return }
+            didUpdateText(textView: textView)
         default:
             break
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -374,10 +374,8 @@ private extension WysiwygComposerViewModel {
             let previousContent = content
             let attributed = try? NSAttributedString(html: generateHtmlBodyWithStyle(htmlFragment: previousContent.plainText))
             clearContent()
-            content = WysiwygComposerContent(plainText: previousContent.plainText,
-                                             html: "",
-                                             attributed: attributed ?? NSAttributedString(string: plainText),
-                                             attributedSelection: previousContent.attributedSelection)
+            guard let textView = textView else { return }
+            textView.attributedText = attributed
         } else {
             // TODO: convert Markdown content to HTML
             let update = model.replaceAllHtml(html: plainText)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -24,7 +24,7 @@ public class WysiwygComposerViewModel: ObservableObject {
     // MARK: - Public
 
     /// The textView with placeholder support that the model manages
-    public var textView: PlaceholdableTextView!
+    public var textView: PlaceholdableTextView?
     /// Published object for the composer content.
     @Published public var content: WysiwygComposerContent = .init()
     /// Published boolean for the composer empty content state.
@@ -56,8 +56,7 @@ public class WysiwygComposerViewModel: ObservableObject {
             // In case of a color change, this will refresh the attributed text
             let update = model.replaceAllHtml(html: content.html)
             applyUpdate(update)
-            guard let textView = textView else { return }
-            didUpdateText(textView: textView)
+            updateTextView()
         }
     }
 
@@ -110,8 +109,7 @@ public class WysiwygComposerViewModel: ObservableObject {
     /// Should be called when the view appears.
     public func setup() {
         applyUpdate(model.replaceAllHtml(html: ""))
-        guard let textView = textView else { return }
-        didUpdateText(textView: textView)
+        updateTextView()
     }
     
     /// Select given range of text within the model.
@@ -171,8 +169,7 @@ public class WysiwygComposerViewModel: ObservableObject {
             update = model.unorderedList()
         }
         applyUpdate(update)
-        guard let textView = textView else { return }
-        didUpdateText(textView: textView)
+        updateTextView()
     }
 
     /// Sets given HTML as the current content of the composer.
@@ -182,15 +179,13 @@ public class WysiwygComposerViewModel: ObservableObject {
     public func setHtmlContent(_ html: String) {
         let update = model.replaceAllHtml(html: html)
         applyUpdate(update)
-        guard let textView = textView else { return }
-        didUpdateText(textView: textView)
+        updateTextView()
     }
 
     /// Clear the content of the composer.
     public func clearContent() {
         applyUpdate(model.clear())
-        guard let textView = textView else { return }
-        didUpdateText(textView: textView)
+        updateTextView()
     }
 
     /// Returns a textual representation of the composer model as a tree.
@@ -278,6 +273,11 @@ public extension WysiwygComposerViewModel {
 // MARK: - Private
 
 private extension WysiwygComposerViewModel {
+    func updateTextView() {
+        guard let textView = textView else { return }
+        didUpdateText(textView: textView)
+    }
+    
     /// Apply given composer update to the composer.
     ///
     /// - Parameter update: ComposerUpdate to apply.
@@ -395,13 +395,12 @@ private extension WysiwygComposerViewModel {
             )
             let attributedText = NSAttributedString(attributedString: mutableAttributed)
             clearContent()
-            guard let textView = textView else { return }
-            textView.attributedText = attributedText
+            updateTextView()
         } else {
             // TODO: convert Markdown content to HTML
             let update = model.replaceAllHtml(html: plainText)
             applyUpdate(update)
-            didUpdateText(textView: textView)
+            updateTextView()
         }
     }
     

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -40,6 +40,8 @@ public class WysiwygComposerViewModel: ObservableObject {
             updateIdealHeight()
         }
     }
+
+    public var textView: UITextView?
     
     /// The current textColor of the attributed string
     public var textColor: UIColor {
@@ -171,7 +173,6 @@ public extension WysiwygComposerViewModel {
     ///   - replacementText: Replacement text to apply.
     func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool {
         let update: ComposerUpdate
-        let shouldAcceptChange: Bool
 
         if range != content.attributedSelection {
             select(text: textView.attributedText!, range: range)
@@ -185,17 +186,12 @@ public extension WysiwygComposerViewModel {
 
         if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
             update = model.enter()
-            shouldAcceptChange = false
         } else {
             update = model.replaceText(newText: replacementText)
-            shouldAcceptChange = true
         }
 
         applyUpdate(update)
-        if !shouldAcceptChange {
-            textView.apply(content)
-        }
-        return shouldAcceptChange
+        return false
     }
 
     /// Notify that the text view content has changed.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -19,8 +19,18 @@ import Foundation
 import OSLog
 import UIKit
 
+public protocol WysiwygComposerViewModelProtocol: AnyObject {
+    var textView: PlaceholdableTextView? { get set }
+    var content: WysiwygComposerContent { get }
+    
+    func updateCompressedHeightIfNeeded(_ textView: UITextView)
+    func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool
+    func select(text: NSAttributedString, range: NSRange)
+    func didUpdateText(textView: UITextView)
+}
+
 /// Main view model for the composer. Forwards actions to the Rust model and publishes resulting states.
-public class WysiwygComposerViewModel: ObservableObject {
+public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, ObservableObject {
     // MARK: - Public
 
     /// The textView with placeholder support that the model manages

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -57,7 +57,7 @@ extension NSAttributedString {
         return font?.fontDescriptor.symbolicTraits ?? []
     }
     
-    /// Changes the attribute of foregroundColor for the whole string
+    /// Changes the attribute of foregroundColor for the whole attributed string
     ///
     /// - Parameters:
     ///   - color: the new UIColor to update the attributed string

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -56,4 +56,18 @@ extension NSAttributedString {
         let font = attribute(.font, at: index, effectiveRange: nil) as? UIFont
         return font?.fontDescriptor.symbolicTraits ?? []
     }
+    
+    /// Changes the attribute of foregroundColor for the whole string
+    ///
+    /// - Parameters:
+    ///   - color: the new UIColor to update the attributed string
+    /// - Returns: a new attributed string with the same content and attributes, but its foregroundColor is changed
+    func changeColor(to color: UIColor) -> NSAttributedString {
+        let mutableAttributed = NSMutableAttributedString(attributedString: self)
+        mutableAttributed.addAttributes(
+            [.foregroundColor: color], range: NSRange(location: 0, length: mutableAttributed.length)
+        )
+        let newSelf = NSAttributedString(attributedString: mutableAttributed)
+        return newSelf
+    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -37,8 +37,11 @@ final class WysiwygComposerViewModelTests: XCTestCase {
                 XCTAssertFalse(isEmpty)
                 expectFalse.fulfill()
             })
+        
+        let textView = UITextView()
+        textView.attributedText = NSAttributedString(string: "")
 
-        _ = viewModel.replaceText(NSAttributedString(string: ""),
+        _ = viewModel.replaceText(textView,
                                   range: .zero,
                                   replacementText: "Test")
 
@@ -55,7 +58,8 @@ final class WysiwygComposerViewModelTests: XCTestCase {
                 expectTrue.fulfill()
             })
 
-        _ = viewModel.replaceText(viewModel.content.attributed,
+        textView.attributedText = viewModel.content.attributed
+        _ = viewModel.replaceText(textView,
                                   range: .init(location: 0, length: viewModel.content.attributed.length),
                                   replacementText: "")
 
@@ -64,14 +68,18 @@ final class WysiwygComposerViewModelTests: XCTestCase {
     }
 
     func testSimpleTextInputIsAccepted() throws {
-        let shouldChange = viewModel.replaceText(NSAttributedString(string: ""),
+        let textView = UITextView()
+        textView.attributedText = NSAttributedString(string: "")
+        let shouldChange = viewModel.replaceText(textView,
                                                  range: .zero,
                                                  replacementText: "A")
         XCTAssertTrue(shouldChange)
     }
 
     func testNewlineIsNotAccepted() throws {
-        let shouldChange = viewModel.replaceText(NSAttributedString(string: ""),
+        let textView = UITextView()
+        textView.attributedText = NSAttributedString(string: "")
+        let shouldChange = viewModel.replaceText(textView,
                                                  range: .zero,
                                                  replacementText: "\n")
         XCTAssertFalse(shouldChange)
@@ -81,7 +89,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         let textView = UITextView()
         let initialText = NSAttributedString(string: "")
         textView.attributedText = initialText
-        _ = viewModel.replaceText(initialText,
+        _ = viewModel.replaceText(textView,
                                   range: .zero,
                                   replacementText: "A")
         textView.attributedText = NSAttributedString(string: "AA")


### PR DESCRIPTION
Reworked the code to allow the delegates only to update the content of the textview to avoid the missing keystroke issue.
Also fixed the delete long press issue.
Wrote UI tests for these issues.