### PR TITLE
[Android] Fix text watchers called with empty string on every change

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,9 @@ on:
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx2560m" -Dkotlin.incremental=false
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4 --no-daemon
+  ARCH: x86_64
+  DEVICE: Nexus 5X
+  UNIFFI_VERSION: 0.19.2
 
 jobs:
   tests:
@@ -19,10 +22,10 @@ jobs:
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Android'))
     name: Run all tests
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
-        api-level: [28]
+        api-level: [31]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -50,7 +53,7 @@ jobs:
         with:
           command: install
           # keep in sync with uniffi dependency in Cargo.toml's
-          args: uniffi_bindgen --version 0.19.2
+          args: uniffi_bindgen --version ${{ env.UNIFFI_VERSION }}
 
       - name: Setup Gradle & Build test cases
         uses: gradle/gradle-build-action@v2
@@ -62,16 +65,40 @@ jobs:
             :library:assembleDebugUnitTest :library:assembleDebugAndroidTest ${{ env.CI_GRADLE_ARG_PROPERTIES }}
           cache-read-only: false
 
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: platforms/android
+          api-level: ${{ matrix.api-level }}
+          profile: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          enable-hw-keyboard: true
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run all the tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           working-directory: platforms/android
           api-level: ${{ matrix.api-level }}
-          arch: x86
-          profile: Nexus 5X
+          arch: ${{ env.ARCH }}
+          profile: ${{ env.DEVICE }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          enable-hw-keyboard: true
           script: |
             ./gradlew :library:testDebugUnitTest :library:connectedDebugAndroidTest ${{ env.CI_GRADLE_ARG_PROPERTIES }}
 

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -1,0 +1,237 @@
+package io.element.android.wysiwyg.inputhandlers
+
+import android.app.Application
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import androidx.test.core.app.ApplicationProvider
+import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
+import io.element.android.wysiwyg.test.utils.dumpSpans
+import io.element.android.wysiwyg.utils.AndroidHtmlConverter
+import io.element.android.wysiwyg.utils.AndroidResourcesProvider
+import io.element.android.wysiwyg.utils.HtmlToSpansParser
+import io.element.android.wysiwyg.viewmodel.EditorViewModel
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import uniffi.wysiwyg_composer.newComposerModel
+
+class InterceptInputConnectionIntegrationTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+    private val viewModel = EditorViewModel(
+        composer = newComposerModel(),
+        htmlConverter = AndroidHtmlConverter(
+            provideHtmlToSpansParser = { html ->
+                HtmlToSpansParser(
+                    AndroidResourcesProvider(app),
+                    html
+                )
+            },
+        )
+    )
+    private val textView = EditText(ApplicationProvider.getApplicationContext())
+    private val inputConnection = InterceptInputConnection(
+        viewModel = viewModel,
+        editorEditText = textView,
+        baseInputConnection = textView.onCreateInputConnection(EditorInfo()),
+    )
+
+    private val baseEditedSpans = listOf(
+        "world: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
+        "world: android.text.method.TextKeyListener (0-5) fl=#18",
+        "world: android.widget.Editor.SpanController (0-5) fl=#18",
+        ": android.text.Selection.START (5-5) fl=#546",
+        ": android.text.Selection.END (5-5) fl=#34",
+    )
+
+    @Test
+    fun testComposeBoldText() {
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Bold))
+        inputConnection.setComposingText("hello", 1)
+
+        assertThat(textView.text.toString(), equalTo("hello"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
+                    "hello: android.text.method.TextKeyListener (0-5) fl=#18",
+                    "hello: android.widget.Editor.SpanController (0-5) fl=#18",
+                    ": android.text.Selection.START (5-5) fl=#546",
+                    ": android.text.Selection.END (5-5) fl=#34",
+                    "hello: android.text.style.StyleSpan (0-5) fl=#33",
+                    "hello: android.text.style.UnderlineSpan (0-5) fl=#289",
+                    "hello: android.view.inputmethod.ComposingText (0-5) fl=#289",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testEditStyledText() {
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Bold))
+        inputConnection.setComposingText("hello", 1)
+        assertThat(textView.text.toString(), equalTo("hello"))
+        inputConnection.setComposingText("world", 1)
+        inputConnection.commitText("world", 1)
+
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                baseEditedSpans + listOf(
+                    "world: android.text.style.StyleSpan (0-5) fl=#33",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testEditUnderlinedText() {
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Underline))
+        inputConnection.setComposingText("hello", 1)
+        assertThat(textView.text.toString(), equalTo("hello"))
+        inputConnection.setComposingText("world", 1)
+        inputConnection.commitText("world", 1)
+
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                baseEditedSpans + listOf(
+                    "world: android.text.style.UnderlineSpan (0-5) fl=#33",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testEditStrikeThroughText() {
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.StrikeThrough))
+        inputConnection.setComposingText("hello", 1)
+        assertThat(textView.text.toString(), equalTo("hello"))
+        inputConnection.setComposingText("world", 1)
+        inputConnection.commitText("world", 1)
+
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                baseEditedSpans + listOf(
+                    "world: android.text.style.StrikethroughSpan (0-5) fl=#33",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testEditInlineCodeText() {
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.InlineCode))
+        inputConnection.setComposingText("hello", 1)
+        assertThat(textView.text.toString(), equalTo("hello"))
+        inputConnection.setComposingText("world", 1)
+        inputConnection.commitText("world", 1)
+
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                baseEditedSpans + listOf(
+                    "world: io.element.android.wysiwyg.spans.InlineCodeSpan (0-5) fl=#33",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testComposeOrderedListByWholeWord() {
+        viewModel.processInput(EditorInputAction.ToggleList(ordered = true))
+        inputConnection.setComposingText("hello", 1)
+
+        assertThat(textView.text.toString(), equalTo("\u200Bhello"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "\u200Bhello: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
+                    "\u200Bhello: android.text.method.TextKeyListener (0-6) fl=#18",
+                    "\u200Bhello: android.widget.Editor.SpanController (0-6) fl=#18",
+                    ": android.text.Selection.START (6-6) fl=#546",
+                    ": android.text.Selection.END (6-6) fl=#34",
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200Bhello: io.element.android.wysiwyg.spans.OrderedListSpan (0-6) fl=#33",
+                    "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
+                    "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testComposeUnorderedListLetterByLetter() {
+        viewModel.processInput(EditorInputAction.ToggleList(ordered = false))
+        inputConnection.setComposingText("h", 1)
+        inputConnection.setComposingText("he", 1)
+        inputConnection.setComposingText("hel", 1)
+        inputConnection.setComposingText("hell", 1)
+        inputConnection.setComposingText("hello", 1)
+
+        assertThat(textView.text.toString(), equalTo("\u200Bhello"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "\u200Bhello: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
+                    "\u200Bhello: android.text.method.TextKeyListener (0-6) fl=#18",
+                    "\u200Bhello: android.widget.Editor.SpanController (0-6) fl=#18",
+                    ": android.text.Selection.START (6-6) fl=#546",
+                    ": android.text.Selection.END (6-6) fl=#34",
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200Bhello: android.text.style.BulletSpan (0-6) fl=#33",
+                    "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
+                    "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testComposeUnorderedListByWholeWord() {
+        viewModel.processInput(EditorInputAction.ToggleList(ordered = false))
+        inputConnection.setComposingText("hello", 1)
+
+        assertThat(textView.text.toString(), equalTo("\u200Bhello"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "\u200Bhello: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
+                    "\u200Bhello: android.text.method.TextKeyListener (0-6) fl=#18",
+                    "\u200Bhello: android.widget.Editor.SpanController (0-6) fl=#18",
+                    ": android.text.Selection.START (6-6) fl=#546",
+                    ": android.text.Selection.END (6-6) fl=#34",
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200Bhello: android.text.style.BulletSpan (0-6) fl=#33",
+                    "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
+                    "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testComposeOrderedListLetterByLetter() {
+        viewModel.processInput(EditorInputAction.ToggleList(ordered = true))
+        inputConnection.setComposingText("h", 1)
+        inputConnection.setComposingText("he", 1)
+        inputConnection.setComposingText("hel", 1)
+        inputConnection.setComposingText("hell", 1)
+        inputConnection.setComposingText("hello", 1)
+
+        assertThat(textView.text.toString(), equalTo("\u200Bhello"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "\u200Bhello: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
+                    "\u200Bhello: android.text.method.TextKeyListener (0-6) fl=#18",
+                    "\u200Bhello: android.widget.Editor.SpanController (0-6) fl=#18",
+                    ": android.text.Selection.START (6-6) fl=#546",
+                    ": android.text.Selection.END (6-6) fl=#34",
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200Bhello: io.element.android.wysiwyg.spans.OrderedListSpan (0-6) fl=#33",
+                    "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
+                    "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
+                )
+            )
+        )
+    }
+}

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -234,4 +234,28 @@ class InterceptInputConnectionIntegrationTest {
             )
         )
     }
+
+    @Test
+    fun testComposeOrderedListLetterWithEmoji() {
+        viewModel.processInput(EditorInputAction.ToggleList(ordered = true))
+        inputConnection.setComposingText("😋", 1)
+        inputConnection.setComposingText("😋😋", 1)
+
+        assertThat(textView.text.toString(), equalTo("\u200B😋😋"))
+        assertThat(
+            textView.text.dumpSpans(), equalTo(
+                listOf(
+                    "\u200B😋😋: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
+                    "\u200B😋😋: android.text.method.TextKeyListener (0-5) fl=#18",
+                    "\u200B😋😋: android.widget.Editor.SpanController (0-5) fl=#18",
+                    ": android.text.Selection.START (5-5) fl=#546",
+                    ": android.text.Selection.END (5-5) fl=#34",
+                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
+                    "\u200B😋😋: io.element.android.wysiwyg.spans.OrderedListSpan (0-5) fl=#33",
+                    "😋😋: android.text.style.UnderlineSpan (1-5) fl=#289",
+                    "😋😋: android.view.inputmethod.ComposingText (1-5) fl=#289",
+                )
+            )
+        )
+    }
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -3,7 +3,6 @@ package io.element.android.wysiwyg.test
 import android.graphics.Typeface
 import android.text.Editable
 import android.text.Spannable
-import android.text.TextWatcher
 import android.text.style.BulletSpan
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
@@ -11,7 +10,6 @@ import android.view.KeyEvent
 import android.view.View
 import android.widget.TextView
 import androidx.core.text.getSpans
-import androidx.core.widget.addTextChangedListener
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.accessibility.AccessibilityChecks
@@ -22,7 +20,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.filters.FlakyTest
 import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.spans.OrderedListSpan
@@ -317,26 +314,18 @@ class EditorEditTextInputTests {
     @Test
     fun testTextWatcher() {
         val textWatcher = spyk<(text: Editable?) -> Unit>({ })
-        scenarioRule.scenario.onActivity {
-            val editText = it.findViewById<EditorEditText>(R.id.rich_text_edit_text)
-
-            editText.addTextChangedListener(
-                onTextChanged = {_,_,_,_ -> },
-                beforeTextChanged = {_,_,_,_ -> },
-                afterTextChanged = textWatcher,
-            )
-
-            editText.setText("text")
-            editText.setSelection(0, 4)
-            editText.toggleInlineFormat(InlineFormat.Bold)
-            editText.toggleInlineFormat(InlineFormat.Underline)
-            editText.toggleInlineFormat(InlineFormat.Italic)
-            editText.toggleInlineFormat(InlineFormat.StrikeThrough)
-            editText.toggleInlineFormat(InlineFormat.InlineCode)
-            editText.toggleList(ordered = true)
-            editText.toggleList(ordered = false)
-            editText.setHtml("<b>text</b>")
-        }
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(EditorActions.addTextWatcher(textWatcher))
+            .perform(EditorActions.setText("text"))
+            .perform(ImeActions.setSelection(0, 4))
+            .perform(EditorActions.toggleFormat(InlineFormat.Bold))
+            .perform(EditorActions.toggleFormat(InlineFormat.Underline))
+            .perform(EditorActions.toggleFormat(InlineFormat.Italic))
+            .perform(EditorActions.toggleFormat(InlineFormat.StrikeThrough))
+            .perform(EditorActions.toggleFormat(InlineFormat.InlineCode))
+            .perform(EditorActions.toggleList(ordered = true))
+            .perform(EditorActions.toggleList(ordered = false))
+            .perform(EditorActions.setHtml("<b>text</b>"))
 
         verify(exactly = 9) {
             textWatcher.invoke(match { it.toString() == "text" })

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -1,6 +1,8 @@
 package io.element.android.wysiwyg.test.utils
 
+import android.text.Editable
 import android.view.View
+import androidx.core.widget.addTextChangedListener
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -9,6 +11,32 @@ import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import org.hamcrest.Matcher
 
 object Editor {
+
+    class SetText(
+        private val text: String,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set text to $text"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            editor.setText(text)
+        }
+    }
+
+    class SetHtml(
+        private val html: String,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set html to $html"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            editor.setHtml(html)
+        }
+    }
 
     class SetLink(
         private val url: String,
@@ -75,12 +103,31 @@ object Editor {
 
     }
 
+    class AddTextWatcher(
+        private val textWatcher: (Editable?) -> Unit,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Add a text watcher"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            editor.addTextChangedListener(
+                onTextChanged = {_,_,_,_ -> },
+                beforeTextChanged = {_,_,_,_ -> },
+                afterTextChanged = textWatcher,
+            )
+        }
+    }
 }
 
 object EditorActions {
+    fun setText(text: String) = Editor.SetText(text)
+    fun setHtml(html: String) = Editor.SetHtml(html)
     fun setLink(url: String) = Editor.SetLink(url)
     fun toggleList(ordered: Boolean) = Editor.ToggleList(ordered)
     fun undo() = Editor.Undo
     fun redo() = Editor.Redo
     fun toggleFormat(format: InlineFormat) = Editor.ToggleFormat(format)
+    fun addTextWatcher(watcher : (Editable?) -> Unit) = Editor.AddTextWatcher(watcher)
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
@@ -96,21 +96,6 @@ class HtmlToSpansParserTest {
         )
     }
 
-    private fun CharSequence.dumpSpans(): List<String> {
-        val spans = mutableListOf<String>()
-        TextUtils.dumpSpans(
-            this, { span ->
-                val spanWithoutHash = span.split(" ").filterIndexed { index, _ ->
-                    index != 1
-                }.joinToString(" ")
-
-                spans.add(spanWithoutHash)
-            }, ""
-        )
-        return spans
-    }
-
-
     private fun convertHtml(html: String) =
         HtmlToSpansParser(
             resourcesProvider = AndroidResourcesProvider(application = ApplicationProvider.getApplicationContext()),

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/SpanUtils.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/SpanUtils.kt
@@ -1,0 +1,17 @@
+package io.element.android.wysiwyg.test.utils
+
+import android.text.TextUtils
+
+fun CharSequence.dumpSpans(): List<String> {
+    val spans = mutableListOf<String>()
+    TextUtils.dumpSpans(
+        this, { span ->
+            val spanWithoutHash = span.split(" ").filterIndexed { index, _ ->
+                index != 1
+            }.joinToString(" ")
+
+            spans.add(spanWithoutHash)
+        }, ""
+    )
+    return spans
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -130,13 +130,16 @@ internal class InterceptInputConnection(
         }
 
         return if (result != null) {
-            var compositionStart = start
-            var compositionEnd = text?.length?.let { it + start } ?: end
             val newText = result.text.subSequence(start, start + (text?.length ?: 0))
-            if(newText.startsWith("\u200b")) {
-                compositionStart += 1
-                compositionEnd += 1
-            }
+
+            // Calculate the new composition range.
+            // If the composer has inserted a zero width whitespace as a list delimiter,
+            // shift the composition indices so that it is not included.
+            val compositionStart = start
+                .let { if (newText.startsWith("\u200b")) it + 1 else it }
+            val compositionEnd = (text?.length?.let { it + start } ?: end)
+                .let { if (newText.startsWith("\u200b")) it + 1 else it }
+
             // Here we restore the background color spans from the IME input. This seems to be
             // important for Japanese input.
             if (text is Spannable && result.text is Spannable) {


### PR DESCRIPTION
This is needed because the editor currently uses `Editable.replace` to replace the entire contents of the editor when the model changes. This method does not replace spans that are not contained within the range resulting in spans which cover the whole range being duplicated.

[`PSU-935`](https://element-io.atlassian.net/browse/PSU-935) [`PSU-910`](https://element-io.atlassian.net/browse/PSU-910)