### PR TITLE
[iOS] Fix bold+italic content in the composer on iOS 14/15

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -413,7 +413,7 @@ private extension WysiwygComposerViewModel {
     }
     
     func generateHtmlBodyWithStyle(htmlFragment: String) -> String {
-        "<html><head><style>body {font-family:-apple-system;font:-apple-system-subheadline;}</style></head><body>\(htmlFragment)</body></html>"
+        "<html><head><style>body {font-family:-apple-system;font:-apple-system-body;}</style></head><body>\(htmlFragment)</body></html>"
     }
 }
 


### PR DESCRIPTION
Fixes the display of Bold+Italic content by moving from `subheadline` to `body` font