### PR TITLE
feat(wasm): Use `WeakRef` to avoid calling `free` manually

### DIFF
--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -34,8 +34,8 @@
     "node": ">= 10"
   },
   "scripts": {
-    "dev-build": "wasm-pack build --profiling --target web --out-name wysiwyg --out-dir ./pkg",
-    "build": "RUSTFLAGS='-C opt-level=s' wasm-pack build --release --target web --out-name wysiwyg --out-dir ./pkg",
+    "dev-build": "WASM_BINDGEN_WEAKREF=1 wasm-pack build --profiling --target web --out-name wysiwyg --out-dir ./pkg",
+    "build": "RUSTFLAGS='-C opt-level=s' WASM_BINDGEN_WEAKREF=1 wasm-pack build --release --target web --out-name wysiwyg --out-dir ./pkg",
     "test": "jest --verbose",
     "doc": "typedoc --tsconfig ."
   }


### PR DESCRIPTION
By asking `wasm-bindgen` to generate JS glue code for `WeakRef` support, it removes the need to call `free` manually to free objects, thus we reduce potential memory leaks inside Rust. See https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html to learn more.

It uses [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) under the hood, I reckon it's quite common and fits into Matrix's clients needs in terms of browser support.